### PR TITLE
Update WGET_URL to use archive.org.

### DIFF
--- a/floppy/01-install-wget.cmd
+++ b/floppy/01-install-wget.cmd
@@ -5,7 +5,7 @@
 title Installing wget. Please wait...
 
 :: bitsadmin can't download http://users.ugent.be/~bpuype/cgi-bin/fetch.pl?dl=wget/wget.exe
-if not defined WGET_URL set WGET_URL=http://users.ugent.be/~bpuype/wget/wget.exe
+if not defined WGET_URL set WGET_URL=https://web.archive.org/web/20140911054858/http://users.ugent.be/~bpuype/wget/wget.exe
 
 for %%i in ("%WGET_URL%") do set filename=%SystemRoot%\%%~nxi
 


### PR DESCRIPTION
This may be a transient error, but the provided wget.exe URL was
throwing HTTP/404 errors, and this was the simplest alternative that
seemed backwards compatible.

Again, this might not be ideal, but was enough to build the boxes again.

Thanks again for the Windows love!