### PR TITLE
Apply Hotfix KB2842230 on Windows 8 & Server 2012 templates.

### DIFF
--- a/eval-win8x64-enterprise-cygwin.json
+++ b/eval-win8x64-enterprise-cygwin.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
@@ -43,6 +45,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd",
@@ -84,6 +88,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"

--- a/eval-win8x64-enterprise.json
+++ b/eval-win8x64-enterprise.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -42,6 +44,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -82,6 +86,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/floppy/hotfix-KB2842230.bat
+++ b/floppy/hotfix-KB2842230.bat
@@ -1,0 +1,53 @@
+:: Windows 8 / Windows 2012 require KB2842230 hotfix to properly honor a
+:: customized MaxMemoryPerShellMB value.
+:: https://support.microsoft.com/en-us/kb/2842230?wa=wsignin1.0
+
+@setlocal EnableDelayedExpansion EnableExtensions
+@for %%i in (%~dp0\_packer_config*.cmd) do @call "%%~i"
+@if defined PACKER_DEBUG (@echo on) else (@echo off)
+
+:: get windows version
+for /f "tokens=2 delims=[]" %%G in ('ver') do (set _version=%%G)
+for /f "tokens=2,3,4 delims=. " %%G in ('echo %_version%') do (set _major=%%G& set _minor=%%H& set _build=%%I)
+
+:: 6.2 or 6.3
+if %_major% neq 6 goto :exit
+if %_minor% lss 2 goto :exit
+if %_minor% gtr 3 goto :exit
+
+title Installing Hotfix KB2842230. Please wait...
+
+if not defined HOTFIX_2842230_URL set HOTFIX_2842230_URL=https://chocolateypackages.s3.amazonaws.com/KB2842230.1.0.2.nupkg
+
+for %%i in (%HOTFIX_2842230_URL%) do set HOTFIX_2842230_EXE=%%~nxi
+set HOTFIX_2842230_DIR=%TEMP%\KB2842230
+set HOTFIX_2842230_PATH=%HOTFIX_2842230_DIR%\%HOTFIX_2842230_EXE%.zip
+
+echo ==^> Creating "%HOTFIX_2842230_DIR%"
+mkdir "%HOTFIX_2842230_DIR%"
+pushd "%HOTFIX_2842230_DIR%"
+
+if exist "%SystemRoot%\_download.cmd" (
+  call "%SystemRoot%\_download.cmd" "%HOTFIX_2842230_URL%" "%HOTFIX_2842230_PATH%"
+) else (
+  echo ==^> Downloading "%HOTFIX_2842230_URL%" to "%HOTFIX_2842230_PATH%"
+  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%HOTFIX_2842230_URL%', '%HOTFIX_2842230_PATH%')" <NUL
+)
+if errorlevel 1 goto exit1
+
+echo ==^> Extracting Hotfix KB2842230
+@for %%i in (%~dp0\unzip.vbs) do @cscript //nologo "%%~i" "%HOTFIX_2842230_PATH%" "%HOTFIX_2842230_DIR%"
+
+echo ==^> Installing Hotfix KB2842230
+@echo on
+start /wait wusa "%HOTFIX_2842230_DIR%\Windows8-RT-KB2842230-x64.msu" /quiet /norestart
+
+:exit0
+
+ver>nul
+
+:exit1
+
+verify other 2>nul
+
+:exit

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -12,6 +12,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -44,6 +46,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -85,6 +89,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -42,6 +44,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -82,6 +86,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -12,6 +12,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -44,6 +46,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -85,6 +89,8 @@
         "floppy/_packer_config.cmd",
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -42,6 +44,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -82,6 +86,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/win8x64-enterprise-cygwin.json
+++ b/win8x64-enterprise-cygwin.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
@@ -43,6 +45,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd",
@@ -84,6 +88,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -42,6 +44,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -82,6 +86,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],

--- a/win8x64-pro-cygwin.json
+++ b/win8x64-pro-cygwin.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"
@@ -43,6 +45,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd",
@@ -84,6 +88,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/cygwin.sh",
         "floppy/cygwin.bat",
         "floppy/zz-start-sshd.cmd"

--- a/win8x64-pro.json
+++ b/win8x64-pro.json
@@ -11,6 +11,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],
@@ -42,6 +44,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
@@ -82,6 +86,8 @@
         "floppy/_download.cmd",
         "floppy/_packer_config.cmd",
         "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
         "floppy/openssh.bat",
         "floppy/zz-start-sshd.cmd"
       ],


### PR DESCRIPTION
Hi there! In preparing the [Test Kitchen](http://kitchen.ci) 1.4.0 release which includes support for testing Windows guests, I became all too familiar with [KB2842230](https://support.microsoft.com/en-us/kb/2842230?wa=wsignin1.0). This is a PR that tries to make the affected Windows versions work better out-of-the-box when automated via WinRM.

---

There is a known issue with WinRM ignoring a customized
MaxMemoryPerShellMB on certain default installations of Windows. In this
project, the issue affects the following templates:

* win2012-datacenter-cygwin
* win2012-datacenter
* win2012-standard-cygwin
* win2012-standard
* win8x64-enterprise-cygwin
* win8x64-enterprise
* win8x64-pro-cygwin
* win8x64-pro

This commit adds a floppy-mountable script (hotfix-KB2842230.bat) which
applies the hotfix to the system. The implementation started as a port
from joefitzgerald/packer-windows but has been heavily customized to
download, extract, and apply the hotfix only to the target Windows
versions. The Microsoft-provided hotfix is a self-extracting .exe file
which has no CMD flags and thus couldn't be automated. Instead, this
implementation uses a Chocolatey package (which is a Zip format)
containing the .msu program.

For more details on KB2842230, interested parties can read:

https://support.microsoft.com/en-us/kb/2842230?wa=wsignin1.0