### PR TITLE
Parameterize disk size and change Virtualbox hard_drive_controller to SATA

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win10x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win10x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win10x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "eval-win10x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win10x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -162,6 +162,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "eval-win2008r2-datacenter-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "eval-win2008r2-datacenter"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "eval-win2008r2-standard-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "eval-win2008r2-standard"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win2012r2-datacenter-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -171,6 +171,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "eval-win2012r2-datacenter"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -168,6 +168,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win2012r2-standard-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -171,6 +171,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "eval-win2012r2-standard"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -168,6 +168,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -37,7 +37,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -82,7 +82,7 @@
       "vm_name": "eval-win7x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -65,6 +65,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -65,6 +65,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -37,7 +37,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -82,7 +82,7 @@
       "vm_name": "eval-win7x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -65,6 +65,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -37,7 +37,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -82,7 +82,7 @@
       "vm_name": "eval-win7x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "eval-win7x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win81x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win81x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -85,7 +85,7 @@
       "vm_name": "eval-win81x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -62,6 +62,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "eval-win81x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -162,6 +162,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win8x64-enterprise-cygwin.json
+++ b/eval-win8x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "eval-win8x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/eval-win8x64-enterprise-cygwin.json
+++ b/eval-win8x64-enterprise-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win8x64-enterprise.json
+++ b/eval-win8x64-enterprise.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/eval-win8x64-enterprise.json
+++ b/eval-win8x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "eval-win8x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/eval-win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2008r2-datacenter-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win2008r2-datacenter"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2008r2-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win2008r2-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2008r2-standard-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win2008r2-standard"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2008r2-web-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win2008r2-web"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win2012-datacenter-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -167,6 +167,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2012-datacenter"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win2012-standard-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -167,6 +167,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win2012-standard"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -164,6 +164,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "win2012r2-datacenter-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -168,6 +168,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -81,7 +81,7 @@
       "vm_name": "win2012r2-datacenter"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "win2012r2-standard-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -168,6 +168,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -81,7 +81,7 @@
       "vm_name": "win2012r2-standard"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "win2012r2-standardcore-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -168,6 +168,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -81,7 +81,7 @@
       "vm_name": "win2012r2-standardcore"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -165,6 +165,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win7x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win7x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win7x64-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win7x64-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win7x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win7x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win7x86-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win7x86-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "win81x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -162,6 +162,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -81,7 +81,7 @@
       "vm_name": "win81x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -159,6 +159,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -83,7 +83,7 @@
       "vm_name": "win81x64-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -162,6 +162,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -81,7 +81,7 @@
       "vm_name": "win81x64-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -159,6 +159,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -77,7 +77,7 @@
       "vm_name": "win81x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -156,6 +156,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -75,7 +75,7 @@
       "vm_name": "win81x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -153,6 +153,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -77,7 +77,7 @@
       "vm_name": "win81x86-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -156,6 +156,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -60,6 +60,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -58,6 +58,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -75,7 +75,7 @@
       "vm_name": "win81x86-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -153,6 +153,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x64-enterprise-cygwin.json
+++ b/win8x64-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win8x64-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x64-enterprise-cygwin.json
+++ b/win8x64-enterprise-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win8x64-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x64-pro-cygwin.json
+++ b/win8x64-pro-cygwin.json
@@ -63,6 +63,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x64-pro-cygwin.json
+++ b/win8x64-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -36,7 +36,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -80,7 +80,7 @@
       "vm_name": "win8x64-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -161,6 +161,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x64-pro.json
+++ b/win8x64-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -35,7 +35,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -78,7 +78,7 @@
       "vm_name": "win8x64-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -158,6 +158,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x64-pro.json
+++ b/win8x64-pro.json
@@ -61,6 +61,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x86-enterprise-cygwin.json
+++ b/win8x86-enterprise-cygwin.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x86-enterprise-cygwin.json
+++ b/win8x86-enterprise-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win8x86-enterprise-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x86-enterprise.json
+++ b/win8x86-enterprise.json
@@ -57,6 +57,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x86-enterprise.json
+++ b/win8x86-enterprise.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -74,7 +74,7 @@
       "vm_name": "win8x86-enterprise"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -152,6 +152,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x86-pro-cygwin.json
+++ b/win8x86-pro-cygwin.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -34,7 +34,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -76,7 +76,7 @@
       "vm_name": "win8x86-pro-cygwin"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -155,6 +155,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x86-pro-cygwin.json
+++ b/win8x86-pro-cygwin.json
@@ -59,6 +59,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",

--- a/win8x86-pro.json
+++ b/win8x86-pro.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -74,7 +74,7 @@
       "vm_name": "win8x86-pro"
     },
     {
-      "disk_size": 40960,
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/00-run-all-scripts.cmd",
@@ -152,6 +152,7 @@
     }
   ],
   "variables": {
+    "disk_size": 40960,
     "cm": "chef",
     "cm_version": "",
     "headless": false,

--- a/win8x86-pro.json
+++ b/win8x86-pro.json
@@ -57,6 +57,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "hard_drive_interface": "sata",
       "vboxmanage": [
         [
           "modifyvm",


### PR DESCRIPTION
VirtualBox uses [SATA as the default for newly created virtual machines] (https://www.virtualbox.org/manual/ch05.html#harddiskcontrollers). Not sure why packer creates an IDE interface.

The other commit is to add disk size as a parameter to make it easier to change.