### PR TITLE
Fix wget.exe's URL

### DIFF
--- a/.windows/provisions/Makefile
+++ b/.windows/provisions/Makefile
@@ -23,7 +23,7 @@ UNXTUTILS_URL?=http://downloads.sourceforge.net/unxutils/UnxUtils.zip
 VAGRANT_PUB_URL?=https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub
 VBOX_ISO_URL=http://download.virtualbox.org/virtualbox/4.3.28/VBoxGuestAdditions_4.3.28.iso
 VMWARE_TOOLS_TAR_URL=https://softwareupdate.vmware.com/cds/vmw-desktop/ws/11.1.2/2780323/windows/packages/tools-windows-9.9.3.exe.tar
-WGET_URL?=https://eternallybored.org/misc/wget/wget.exe
+WGET_URL?=https://eternallybored.org/misc/wget/current/wget.exe
 
 BITVISE:=$(shell basename $(BITVISE_URL))
 CHEF:=chef-client-latest.msi

--- a/floppy/01-install-wget.cmd
+++ b/floppy/01-install-wget.cmd
@@ -6,7 +6,7 @@ echo on
 
 title Installing wget. Please wait...
 
-if not defined WGET_URL set WGET_URL=https://eternallybored.org/misc/wget/wget.exe
+if not defined WGET_URL set WGET_URL=https://eternallybored.org/misc/wget/current/wget.exe
 
 for %%i in ("%WGET_URL%") do set filename=%SystemRoot%\%%~nxi
 


### PR DESCRIPTION
Btw. the original URL returns an HTML page, which before this patch was then saved as `wget.exe`. This lead to e.g. Windows 7 Pro eval build complain about not being able to execute 16-bit software on 64-bit Windows, which required a user to click "OK". It seems `_download.cmd` then simply tried other download options (like downloading through PowerShell just the way `wget.exe` was originally downloaded) and the build eventually succeeded, but it required the interaction of a user, thus making it not fully unattended.