### PR TITLE
Detect OS version correctly on non-English Windows

### DIFF
--- a/floppy/cygwin.bat
+++ b/floppy/cygwin.bat
@@ -9,7 +9,7 @@ if not defined CYGWIN_ARCH (
   set CYGWIN_ARCH=x86
 
   :: Force CYGWIN_ARCH to 64-bit - 32-bit seems to crash a lot on Windows 2008 and 2012
-  systeminfo 2>nul  | findstr /b /c:"OS Name" | findstr "2008 2012" >nul
+  wmic os get Caption | findstr "2008 2012" >nul
   if not errorlevel 1 set CYGWIN_ARCH=x86_64
 )
 

--- a/floppy/install-winrm.cmd
+++ b/floppy/install-winrm.cmd
@@ -21,7 +21,7 @@ if exist %SystemRoot%\SysWOW64\cmd.exe (
   @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force" <NUL
 )
 
-systeminfo 2>nul | findstr /b /c:"OS Name" | findstr /c:"Windows 7" /c:"Windows 10" >nul
+wmic os get Caption | findstr /c:"Windows 7" /c:"Windows 10" >nul
 if errorlevel 1 goto skip_fixnetwork
 
 if not exist a:\fixnetwork.ps1 echo ==^> ERROR: File not found: a:\fixnetwork.ps1


### PR DESCRIPTION
`systeminfo` output is localized (bad for `findstr`), `wmic` output is not (good for `findstr`)

Tested on:
- Win 7 x86 Pro SP1 Czech
- Win 7 x64 Enterprise Eval EN
- Win 10 x86 Enterprise Eval EN
  - if `fixnetwork.ps1` is not run, winrm indeed fails to launch
  - if `findstr` after `wmic` is modified to search for "Windows 9" instead of "Windows 10", winrm does fail to launch (to rule out some typo leading to the line always returning true)
  - in the committed form, winrm launches and provisioning starts
- Win 2008R2
  - to rule out that `wmic` and `systeminfo` have different behavior between Win 7 and Win 2008 R2 (which are in a way the same version of an OS)

Did not test with cygwin templates, but the command is identical, so it should be fine.

Fixes #45