### PR TITLE
Update.bat reboot fix

### DIFF
--- a/floppy/_post_update_install.bat
+++ b/floppy/_post_update_install.bat
@@ -1,1 +1,5 @@
+ECHO OFF
+REM This script is not included on the floppy by default.
+REM If you're using update.bat, include this file if you
+REM want to run scripts following all updates/reboots.
 a:\zz-start-sshd.cmd

--- a/floppy/_post_update_install.bat
+++ b/floppy/_post_update_install.bat
@@ -1,0 +1,1 @@
+a:\zz-start-sshd.cmd

--- a/floppy/update.bat
+++ b/floppy/update.bat
@@ -38,6 +38,7 @@ If searchResult.Updates.Count Then
 End if 
 If searchResult.Updates.Count = 0 Then
     LogWrite "There are no applicable updates."
+    ExecutePostInstallBatch
     WScript.Quit
 End If
 
@@ -50,7 +51,11 @@ If installResult.RebootRequired Then
     reboot(".")
     WScript.Quit
 Else
-    Dim fso    
+    ExecutePostInstallBatch
+End If
+
+Sub ExecutePostInstallBatch
+    Dim fso
     Set fso = CreateObject("Scripting.FileSystemObject")
 
     If (fso.FileExists("a:\_post_update_install.bat")) Then
@@ -58,7 +63,7 @@ Else
         Set objShell = WScript.CreateObject("WScript.Shell")
         objShell.Run "a:\_post_update_install.bat"
     End If
-End If
+End Sub
 
 Sub LogWrite(message)
     Dim strFile, objFSO, objFile

--- a/floppy/update.bat
+++ b/floppy/update.bat
@@ -48,6 +48,16 @@ Set installResult = installUpdates(updateSession, updatesToInstall)
 If installResult.RebootRequired Then
     addStartupEntry
     reboot(".")
+    WScript.Quit
+Else
+    Dim fso    
+    Set fso = CreateObject("Scripting.FileSystemObject")
+
+    If (fso.FileExists("a:\_post_update_install.bat")) Then
+        Dim objShell
+        Set objShell = WScript.CreateObject("WScript.Shell")
+        objShell.Run "a:\_post_update_install.bat"
+    End If
 End If
 
 Sub LogWrite(message)


### PR DESCRIPTION
When update.bat triggers a reboot, scripts following it on the floppy won't execute...mainly zz-start-sshd.cmd.  Added a sub to the VBScript code to run _post_update_install.bat if it exists on the floppy.

This will fix the issue with scripts not running post-install, but could introduce an instance where updates don't trigger a reboot, the _post_update_install.bat file executes, and execution of 00-run-all-scripts.cmd continues on to execute the remaining scripts.  I think as long as the scripts included in _post_update_install.bat are kept to a minimum, it should be fine.