### PR TITLE
Update Salt Minion URL and bump current version

### DIFF
--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -118,11 +118,11 @@ goto exit0
 :salt
 ::::::::::::
 
-if "%CM_VERSION%" == "latest" set CM_VERSION=2015.5.0
+if "%CM_VERSION%" == "latest" set CM_VERSION=2015.8.8-2
 
-if not defined SALT_64_URL set SALT_64_URL=https://docs.saltstack.com/downloads/Salt-Minion-%CM_VERSION%-AMD64-Setup.exe
+if not defined SALT_64_URL set SALT_64_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-AMD64-Setup.exe
 
-if not defined SALT_32_URL set SALT_32_URL=https://docs.saltstack.com/downloads/Salt-Minion-%CM_VERSION%-x86-Setup.exe
+if not defined SALT_32_URL set SALT_32_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-x86-Setup.exe
 
 if defined ProgramFiles(x86) (
   set SALT_URL=%SALT_64_URL%


### PR DESCRIPTION
Updating URL per https://github.com/saltstack/salt-bootstrap/pull/711/commits/05f344c596af9efd7b13b4e31f3e6366140409f3 and bumping the current version to 2015.8.8-2