### PR TITLE
Set virtualbox-iso guest_additions_mode to attach

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -54,6 +54,7 @@
         "floppy/update.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -52,6 +52,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows81",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -53,6 +53,7 @@
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -51,6 +51,7 @@
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -52,6 +52,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -52,6 +52,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -55,6 +55,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -55,6 +55,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -55,6 +55,7 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -55,6 +55,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -53,6 +53,7 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -54,6 +54,7 @@
         "floppy/update.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -52,6 +52,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -52,6 +52,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win8x64-enterprise-cygwin.json
+++ b/eval-win8x64-enterprise-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win8x64-enterprise-ssh.json
+++ b/eval-win8x64-enterprise-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/eval-win8x64-enterprise.json
+++ b/eval-win8x64-enterprise.json
@@ -53,6 +53,7 @@
         "floppy/unzip.vbs",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -51,6 +51,7 @@
         "floppy/win2008r2-datacenter/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -51,6 +51,7 @@
         "floppy/win2008r2-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -51,6 +51,7 @@
         "floppy/win2008r2-standard/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -51,6 +51,7 @@
         "floppy/win2008r2-web/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2008_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -53,6 +53,7 @@
         "floppy/win2012-datacenter/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -53,6 +53,7 @@
         "floppy/win2012-standard/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -50,6 +50,7 @@
         "floppy/win2012r2-datacenter/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -50,6 +50,7 @@
         "floppy/win2012r2-standard/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -50,6 +50,7 @@
         "floppy/win2012r2-standardcore/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -51,6 +51,7 @@
         "floppy/win7x64-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -51,6 +51,7 @@
         "floppy/win7x64-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -51,6 +51,7 @@
         "floppy/win7x86-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -51,6 +51,7 @@
         "floppy/win7x86-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows7",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -50,6 +50,7 @@
         "floppy/win81x64-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -50,6 +50,7 @@
         "floppy/win81x64-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -50,6 +50,7 @@
         "floppy/win81x86-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -50,6 +50,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -48,6 +48,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -50,6 +50,7 @@
         "floppy/win81x86-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-enterprise-cygwin.json
+++ b/win8x64-enterprise-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-enterprise-ssh.json
+++ b/win8x64-enterprise-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-enterprise.json
+++ b/win8x64-enterprise.json
@@ -53,6 +53,7 @@
         "floppy/win8x64-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-pro-cygwin.json
+++ b/win8x64-pro-cygwin.json
@@ -53,6 +53,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-pro-ssh.json
+++ b/win8x64-pro-ssh.json
@@ -51,6 +51,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x64-pro.json
+++ b/win8x64-pro.json
@@ -53,6 +53,7 @@
         "floppy/win8x64-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-enterprise-cygwin.json
+++ b/win8x86-enterprise-cygwin.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-enterprise-ssh.json
+++ b/win8x86-enterprise-ssh.json
@@ -47,6 +47,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-enterprise.json
+++ b/win8x86-enterprise.json
@@ -49,6 +49,7 @@
         "floppy/win8x86-enterprise/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-pro-cygwin.json
+++ b/win8x86-pro-cygwin.json
@@ -49,6 +49,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-pro-ssh.json
+++ b/win8x86-pro-ssh.json
@@ -47,6 +47,7 @@
         "floppy/zz-start-sshd.cmd",
         "floppy/oracle-cert.cer"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",

--- a/win8x86-pro.json
+++ b/win8x86-pro.json
@@ -49,6 +49,7 @@
         "floppy/win8x86-pro/Autounattend.xml",
         "floppy/zz-start-sshd.cmd"
       ],
+      "guest_additions_mode": "attach",
       "guest_os_type": "Windows8",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",


### PR DESCRIPTION
The virtualbox-iso builder performs faster and more reliably using
guest_additions_mode `attach` rather than the default of `upload`.

See discussion at https://github.com/boxcutter/windows/issues/53
