### PR TITLE
Add scripts for feature install/removal

### DIFF
--- a/floppy/install-features.cmd
+++ b/floppy/install-features.cmd
@@ -1,0 +1,33 @@
+@setlocal EnableDelayedExpansion EnableExtensions
+@for %%i in (%~dp0\_packer_config*.cmd) do @call "%%~i"
+@if defined PACKER_DEBUG (@echo on) else (@echo off)
+
+if not defined INSTALL_FEATURES set INSTALL_FEATURES=TelnetClient
+
+title Installing features. Please wait...
+
+for %%f in (%INSTALL_FEATURES%) do (
+  echo ==^> Checking if the %%f feature is installed
+  @set CurrentFeature=''
+  for /f "tokens=2 delims=:" %%s in (
+    'Dism /Online /Get-FeatureInfo /FeatureName:%%f ^| find "State : "') do (
+    @set CurrentFeature="%%s"
+  )
+  if not !CurrentFeature!==" Enabled" (
+    echo ==^> Installing the %%f feature
+    Dism /Online /Enable-Feature /FeatureName:%%f /All
+    @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: Dism /Online /Enable-Feature /FeatureName:%%f /All
+  )
+)
+
+:exit0
+
+ver>nul
+
+goto :exit
+
+:exit1
+
+verify other 2>nul
+
+:exit

--- a/floppy/remove-features.cmd
+++ b/floppy/remove-features.cmd
@@ -1,0 +1,33 @@
+@setlocal EnableDelayedExpansion EnableExtensions
+@for %%i in (%~dp0\_packer_config*.cmd) do @call "%%~i"
+@if defined PACKER_DEBUG (@echo on) else (@echo off)
+
+if not defined REMOVE_FEATURES set REMOVE_FEATURES=InkAndHandwritingServices
+
+title Removing features. Please wait...
+
+for %%f in (%REMOVE_FEATURES%) do (
+  echo ==^> Checking if the %%f feature is removed
+  @set CurrentFeature=''
+  for /f "tokens=2 delims=:" %%s in (
+    'Dism /Online /Get-FeatureInfo /FeatureName:%%f ^| find "State : "') do (
+    @set CurrentFeature="%%s"
+  )
+  if not !CurrentFeature!==" Disabled with Payload Removed" (
+    echo ==^> Removing the %%f feature
+    Dism /Online /Disable-Feature /FeatureName:%%f /Remove
+    @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: Dism /Online /Disable-Feature /FeatureName:%%f /Remove
+  )
+)
+
+:exit0
+
+ver>nul
+
+goto :exit
+
+:exit1
+
+verify other 2>nul
+
+:exit


### PR DESCRIPTION
### This PR does the following:

* Adds cmd scripts for the installation and removal of Windows Server Features, leveraging Dism in order to accomplish each, on Windows operating systems that include Dism.
* Having this ability is desirable in that removing unused features can significantly reduce final image size, and pre-installation can reduce deployment time.

### Testing:
* Tested successfully as part of a Packer build of Windows Server 2012R2 images.

### Notes:
* The install script defaults to installing the TelnetClient feature, and the removal script defaults to removing the InkAndHandwritingServices feature. I can remove these entries and have it default to performing a no-op if so desired.