### PR TITLE
Allow multiple scripts to be called from post update

### DIFF
--- a/floppy/_post_update_install.bat
+++ b/floppy/_post_update_install.bat
@@ -1,5 +1,23 @@
-ECHO OFF
+@setlocal EnableDelayedExpansion EnableExtensions
+@for %%i in (%~dp0\_packer_config*.cmd) do @call "%%~i"
+@if defined PACKER_DEBUG (@echo on) else (@echo off)
+
 REM This script is not included on the floppy by default.
 REM If you're using update.bat, include this file if you
 REM want to run scripts following all updates/reboots.
-a:\zz-start-sshd.cmd
+
+title Running post update scripts. Please wait...
+
+@for %%i in (%~dp0\zz*.cmd) do (
+  echo ==^> Running "%%~i"  
+  @call "%%~i"
+)
+
+:exit0
+ver>nul
+goto :exit
+
+:exit1
+verify other 2>nul
+
+:exit


### PR DESCRIPTION
### This PR does the following:

* Modifies the _post_update_install.bat to allow calling multiple scripts after updates complete (calls all present .cmd scripts with the zz prefix), instead of the static reference to zz-start-sshd.cmd.
* Adds debug logging when the appropriate flag is set.

### Testing:
* Tested successfully as part of a Packer build of Windows Server 2012R2 images.