### PR TITLE
Give Win7 more resources so it can install updates in time

### DIFF
--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -32,8 +32,8 @@
       "vm_name": "eval-win7x64-enterprise-cygwin",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1"
+        "memsize": "3072",
+        "numvcpus": "2"
       }
     },
     {
@@ -71,13 +71,13 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "2048"
+          "3072"
         ],
         [
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x64-enterprise-cygwin"
@@ -111,13 +111,13 @@
           "set",
           "{{.Name}}",
           "--memsize",
-          "2048"
+          "3072"
         ],
         [
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -32,8 +32,8 @@
       "vm_name": "eval-win7x64-enterprise-ssh",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1"
+        "memsize": "3072",
+        "numvcpus": "2"
       }
     },
     {
@@ -71,13 +71,13 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "2048"
+          "3072"
         ],
         [
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x64-enterprise-ssh"
@@ -111,13 +111,13 @@
           "set",
           "{{.Name}}",
           "--memsize",
-          "2048"
+          "3072"
         ],
         [
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -29,8 +29,8 @@
       "vm_name": "eval-win7x64-enterprise",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1"
+        "memsize": "3072",
+        "numvcpus": "2"
       },
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
@@ -68,13 +68,13 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "2048"
+          "3072"
         ],
         [
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x64-enterprise",
@@ -111,20 +111,20 @@
           "set",
           "{{.Name}}",
           "--memsize",
-          "2048"
+          "3072"
         ],
         [
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
       "vm_name": "eval-win7x64-enterprise",
       "winrm_password": "vagrant",
-      "winrm_timeout": "10000s",
+      "winrm_timeout": "20000s",
       "winrm_username": "vagrant"
     }
   ],

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -33,7 +33,7 @@
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1536",
-        "numvcpus": "1"
+        "numvcpus": "2"
       }
     },
     {
@@ -77,7 +77,7 @@
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x86-enterprise-cygwin"
@@ -117,7 +117,7 @@
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -32,7 +32,7 @@
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1536",
-        "numvcpus": "1"
+        "numvcpus": "2"
       }
     },
     {
@@ -75,7 +75,7 @@
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x86-enterprise-ssh"
@@ -114,7 +114,7 @@
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -29,7 +29,7 @@
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1536",
-        "numvcpus": "1"
+        "numvcpus": "2"
       },
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
@@ -72,7 +72,7 @@
           "modifyvm",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "vm_name": "eval-win7x86-enterprise",
@@ -114,7 +114,7 @@
           "set",
           "{{.Name}}",
           "--cpus",
-          "1"
+          "2"
         ]
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",


### PR DESCRIPTION
Even when building on modern hardware 1 core and 2 GB is not enough to finish before the timeout happens in packer. There's a service pack and then 251 more updates. We need more ram and CPU

Signed-off-by: Tim Smith <tsmith@chef.io>