### PR TITLE
Slim down Windows 10

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -3,6 +3,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -42,6 +43,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -98,6 +100,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -3,6 +3,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -41,6 +42,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -96,6 +98,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -4,6 +4,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -42,6 +43,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -97,6 +99,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -3,6 +3,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -42,6 +43,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -98,6 +100,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -3,6 +3,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -41,6 +42,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -96,6 +98,7 @@
     {
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -4,6 +4,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -42,6 +43,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",
@@ -97,6 +99,7 @@
       "communicator": "winrm",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
+        "floppy/slim_win10.bat",
         "floppy/00-run-all-scripts.cmd",
         "floppy/01-install-wget.cmd",
         "floppy/_download.cmd",

--- a/floppy/slim_win10.bat
+++ b/floppy/slim_win10.bat
@@ -1,0 +1,36 @@
+<!-- :
+@setlocal EnableDelayedExpansion EnableExtensions
+@for %%i in (%~dp0\_packer_config*.cmd) do @call "%%~i"
+@if defined PACKER_DEBUG (@echo on) else (@echo off)
+
+echo ==^> Disabling auto downloading for the store
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" /v "AutoDownload" /t REG_DWORD /d 2 /f
+
+echo ==^> Disabling Cortana
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v AllowCortana /t REG_DWORD /d 0 /f
+
+echo ==^> Disabling Windows Defender
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" /v DisableAntiSpyware /t REG_DWORD /d 1 /f
+
+echo ==^> Disabling feedback prompts
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Siuf\Rules" /t REG_DWORD /v "NumberOfSIUFInPeriod" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Siuf\Rules" /t REG_DWORD /v "PeriodInNanoSeconds" /d 0 /f
+
+echo ==^> Disabling telemetry
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /t REG_DWORD /v "AITEnable" /d 0 /f      
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /t REG_DWORD /v "DisableInventory" /d 1 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /t REG_DWORD /v "DisableUAR" /d 1 /f
+
+echo ==^> Disabling Ads and Suggestions
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "SystemPaneSuggestionsEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "SoftLandingEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "RotatingLockScreenEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "RotatingLockScreenOverlayEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "SystemPaneSuggestionsEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "PreInstalledAppsEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "PreInstalledAppsEverEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "OEMPreInstalledAppsEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /t REG_DWORD /v "ShowSyncProviderNotifications" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "SilentInstalledAppsEnabled" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "ContentDeliveryAllowed" /d 0 /f
+Reg Add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /t REG_DWORD /v "SubscribedContentEnabled" /d 0 /f


### PR DESCRIPTION
Remove things we don't need for a vagrant box. Ads, personalization,
windows defender, cortana, feedback prompts.

Signed-off-by: Tim Smith <tsmith@chef.io>