### PR TITLE
Feature/hyperv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ tmp
 .vagrant/
 *.swp
 Makefile.local
+rspec_html_reports
 
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ifdef PACKER_DEBUG
 	PACKER := PACKER_LOG=1 $(PACKER)
 else
 endif
-BUILDER_TYPES ?= vmware virtualbox parallels
+BUILDER_TYPES ?= vmware virtualbox parallels hyperv
 ifeq ($(OS),Windows_NT)
 	VAGRANT_PROVIDER ?= vmware_workstation
 else
@@ -112,16 +112,20 @@ TEST_BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $
 VMWARE_BOX_DIR := box/vmware
 VIRTUALBOX_BOX_DIR := box/virtualbox
 PARALLELS_BOX_DIR := box/parallels
+HYPERV_BOX_DIR := box/hyperv
 VMWARE_BOX_FILES := $(foreach box_filename, $(BOX_FILENAMES), $(VMWARE_BOX_DIR)/$(box_filename))
 VIRTUALBOX_BOX_FILES := $(foreach box_filename, $(BOX_FILENAMES), $(VIRTUALBOX_BOX_DIR)/$(box_filename))
 PARALLELS_BOX_FILES := $(foreach box_filename, $(BOX_FILENAMES), $(PARALLELS_BOX_DIR)/$(box_filename))
+HYPERV_BOX_FILES := $(foreach box_filename, $(BOX_FILENAMES), $(HYPERV_BOX_DIR)/$(box_filename))
 BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), box/$(builder)/$(box_filename)))
 VMWARE_OUTPUT := output-vmware-iso
 VIRTUALBOX_OUTPUT := output-virtualbox-iso
 PARALLELS_OUTPUT := output-parallels-iso
+HYPERV_OUTPUT := output-hyperv-iso
 VMWARE_BUILDER := vmware-iso
 VIRTUALBOX_BUILDER := virtualbox-iso
 PARALLELS_BUILDER := parallels-iso
+HYPERV_BUILDER := hyperv-iso
 CURRENT_DIR := $(shell pwd)
 UNAME_O := $(shell uname -o 2> /dev/null)
 UNAME_P := $(shell uname -p 2> /dev/null)
@@ -194,6 +198,12 @@ parallels/$(1)-cygwin: $(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
 
 parallels/$(1)-ssh: $(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
 
+hyperv/$(1): $(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+hyperv/$(1)-cygwin: $(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+
+hyperv/$(1)-ssh: $(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+
 test-vmware/$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 test-vmware/$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
@@ -211,6 +221,12 @@ test-parallels/$(1): test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
 test-parallels/$(1)-cygwin: test-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
 
 test-parallels/$(1)-ssh: test-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+
+test-hyperv/$(1): test-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+test-hyperv/$(1)-cygwin: test-$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+
+test-hyperv/$(1)-ssh: test-$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
 
 ssh-vmware/$(1): ssh-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
@@ -230,11 +246,19 @@ ssh-parallels/$(1)-cygwin: ssh-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
 
 ssh-parallels/$(1)-ssh: ssh-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
 
+ssh-hyperv/$(1): ssh-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+ssh-hyperv/$(1)-cygwin: ssh-$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+
+ssh-hyperv/$(1)-ssh: ssh-$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+
 s3cp-vmware/$(1): s3cp-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 s3cp-virtualbox/$(1): s3cp-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 s3cp-parallels/$(1): s3cp-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+s3cp-hyperv/$(1): s3cp-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
 endef
 
 SHORTCUT_TARGETS := $(basename $(TEMPLATE_FILENAMES))
@@ -393,6 +417,11 @@ $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
 	mkdir -p $(PARALLELS_BOX_DIR)
 	$(PACKER) build -on-error=$(ON_ERROR) -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
 
+$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
+	rm -rf $(HYPERV_OUTPUT)
+	mkdir -p $(HYPERV_BOX_DIR)
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
+
 $(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
@@ -407,6 +436,11 @@ $(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
 	rm -rf $(PARALLELS_OUTPUT)
 	mkdir -p $(PARALLELS_BOX_DIR)
 	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
+
+$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
+	rm -rf $(HYPERV_OUTPUT)
+	mkdir -p $(HYPERV_BOX_DIR)
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
 
 $(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
 	rm -rf $(VIRTUALBOX_OUTPUT)
@@ -423,6 +457,10 @@ $(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
 	mkdir -p $(PARALLELS_BOX_DIR)
 	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
 
+$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
+	rm -rf $(HYPERV_OUTPUT)
+	mkdir -p $(HYPERV_BOX_DIR)
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
 endef
 
 $(eval $(call BUILDBOX,win2008r2-datacenter,$(WIN2008R2_X64),$(WIN2008R2_X64_CHECKSUM)))
@@ -518,7 +556,7 @@ list:
 	@echo "To build for all target platforms:"
 	@echo "  make win7x64-pro"
 	@echo ""
-	@echo "Prepend 'vmware/' or 'virtualbox/' or 'parallels/' to build only one target platform:"
+	@echo "Prepend 'vmware/' or 'virtualbox/' or 'parallels/' or 'hyperv/' to build only one target platform:"
 	@echo "  make vmware/win7x64-pro"
 	@echo ""
 	@echo "Append '-cygwin' to use Cygwin's SSH instead of OpenSSH:"
@@ -570,6 +608,10 @@ test-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
 	-test -f .keep_known_hosts || rm -f ~/.ssh/known_hosts
 	bin/test-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb
 
+test-$(HYPERV_BOX_DIR)/%$(BOX_SUFFIX): $(HYPERV_BOX_DIR)/%$(BOX_SUFFIX)
+	-test -f .keep_known_hosts || rm -f ~/.ssh/known_hosts
+	bin/test-box.sh $< hyperv hyperv $(CURRENT_DIR)/test/*_spec.rb
+
 ssh-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	-test -f .keep_known_hosts || rm -f ~/.ssh/known_hosts
 	bin/ssh-box.sh $< vmware_desktop $(VAGRANT_PROVIDER) $(CURRENT_DIR)/test/*_spec.rb
@@ -581,6 +623,10 @@ ssh-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
 ssh-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
 	-test -f .keep_known_hosts || rm -f ~/.ssh/known_hosts
 	bin/ssh-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb
+
+ssh-$(HYPERV_BOX_DIR)/%$(BOX_SUFFIX): $(HYPERV_BOX_DIR)/%$(BOX_SUFFIX)
+	-test -f .keep_known_hosts || rm -f ~/.ssh/known_hosts
+	bin/ssh-box.sh $< hyperv hyperv $(CURRENT_DIR)/test/*_spec.rb
 
 S3_STORAGE_CLASS ?= REDUCED_REDUNDANCY
 S3_ALLUSERS_ID ?= uri=http://acs.amazonaws.com/groups/global/AllUsers
@@ -594,6 +640,10 @@ s3cp-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
 s3cp-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
 	aws s3 cp $< $(PARALLELS_S3_BUCKET) --storage-class $(S3_STORAGE_CLASS) --grants full=$(S3_GRANT_ID) read=$(S3_ALLUSERS_ID)
 
+s3cp-$(HYPERV_BOX_DIR)/%$(BOX_SUFFIX): $(HYPERV_BOX_DIR)/%$(BOX_SUFFIX)
+	aws s3 cp $< $(HYPERV_S3_BUCKET) --storage-class $(S3_STORAGE_CLASS) --grants full=$(S3_GRANT_ID) read=$(S3_ALLUSERS_ID)
+
 s3cp-vmware: $(addprefix s3cp-,$(VMWARE_BOX_FILES))
 s3cp-virtualbox: $(addprefix s3cp-,$(VIRTUALBOX_BOX_FILES))
 s3cp-parallels: $(addprefix s3cp-,$(PARALLELS_BOX_FILES))
+s3cp-hyperv: $(addprefix s3cp-,$(HYPERV_BOX_FILES))

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -144,6 +144,40 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win10x64-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win10x64-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -72,7 +72,7 @@
       "post_shutdown_delay": "30s",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
+      "ssh_timeout": "10000s",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [
@@ -140,6 +140,39 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
+      "vm_name": "eval-win10x64-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/openssh.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
       "vm_name": "eval-win10x64-enterprise-ssh"
     }
   ],

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -141,6 +141,39 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x64-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win10x64-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -144,6 +144,40 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win10x86-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x86-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win10x86-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -141,6 +141,39 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win10x86-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x86-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/openssh.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win10x86-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -141,6 +141,39 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/slim_win10.bat",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/_post_update_install.bat",
+        "floppy/autologon.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win10x86-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win10x86-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2008r2-datacenter-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-datacenter-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2008r2-datacenter-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/upgrade-wua.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-datacenter-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -125,6 +125,36 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/upgrade-wua.bat",
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-datacenter",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2008r2-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -119,6 +119,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2008r2-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-standard-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -122,6 +122,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2008r2-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -135,6 +135,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2012r2-datacenter-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-datacenter-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2012r2-datacenter-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-datacenter-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -135,6 +135,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win2012r2-datacenter/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-datacenter",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -135,6 +135,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2012r2-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2012r2-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-standard-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -135,6 +135,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win2012r2-standard/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2012r2-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -135,6 +135,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2016-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2016-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2016-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win2016-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win2016-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2016-standard-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -135,6 +135,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win2016-standard/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win2016-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -137,6 +137,37 @@
       "output": "box/{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x64-enterprise-cygwin"
     }
   ],
   "provisioners": [

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -128,6 +128,37 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win7x64-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/openssh.bat",
+        "floppy/upgrade-wua.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x64-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -128,6 +128,37 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "20000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/upgrade-wua.bat",
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x64-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -128,6 +128,37 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win7x86-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x86-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -125,6 +125,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win7x86-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x86-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -125,6 +125,36 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win7x86-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -129,6 +129,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win81x64-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x64-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -129,6 +129,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win81x64-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/update.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x64-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -141,6 +141,36 @@
       "output": "box/{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "tpl/vagrantfile-eval-win81x64-enterprise.tpl"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win81x64-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/update.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x64-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "provisioners": [

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -129,6 +129,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win81x86-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x86-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -126,6 +126,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win81x86-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/eval-win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x86-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -129,6 +129,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/eval-win81x86-enterprise/Autounattend.xml",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "eval-win81x86-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/script/vmtool.bat
+++ b/script/vmtool.bat
@@ -1,3 +1,4 @@
+:: TODO: add steps to download hyperv Integration Tools .cab file based on OS and install them if the user hasn't specific their own URL
 @setlocal EnableDelayedExpansion EnableExtensions
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
@@ -88,6 +89,8 @@ echo "%PACKER_BUILDER_TYPE%" | findstr /i "virtualbox" >nul
 if not errorlevel 1 goto virtualbox
 echo "%PACKER_BUILDER_TYPE%" | findstr /i "parallels" >nul
 if not errorlevel 1 goto parallels
+echo "%PACKER_BUILDER_TYPE%" | findstr /i "hyperv" >nul
+if not errorlevel 1 goto hyperv
 echo ==^> ERROR: Unknown PACKER_BUILDER_TYPE: "%PACKER_BUILDER_TYPE%"
 pushd .
 goto exit1
@@ -255,6 +258,31 @@ echo ==^> Cleaning up Parallels Tools install
 del /F /S /Q "%PARALLELS_DIR"
 echo ==^> Removing "%PARALLELS_ISO_PATH"
 del /F "%PARALLELS_ISO_PATH"
+goto :exit0
+
+::::::::::::
+:hyperv
+::::::::::::
+for /F "usebackq tokens=3,4,5" %%i in (`REG query "hklm\software\microsoft\windows NT\CurrentVersion" /v ProductName`) do set GUEST_OS=%%i %%j %%k
+
+set GUEST_OS
+
+if "%GUEST_OS%" == "Windows Server 2016" goto :exit0
+
+::First, download the appropriate Windows Update CAB file from here: https://support.microsoft.com/en-us/kb/3063109
+::  Windows 8.1: http://www.microsoft.com/downloads/details.aspx?familyid=cd142c42-204a-4566-b767-795e3409b135
+::  Windows 8.1: http://www.microsoft.com/downloads/details.aspx?familyid=3a5a9015-c121-44dd-ad2e-962f66532da7
+::  Windows Server 2012 R2: http://www.microsoft.com/downloads/details.aspx?familyid=a7704851-70bb-46c1-96d2-1b6f7ca226af
+::  Windows Server 2012: http://www.microsoft.com/downloads/details.aspx?familyid=185812c8-8eb5-43c8-8505-70a262f4277d
+::  Windows 7: http://www.microsoft.com/downloads/details.aspx?familyid=54c62651-0fc9-4642-ad12-404b3356825e
+::  Windows 7: http://www.microsoft.com/downloads/details.aspx?familyid=c84f2899-d997-42af-bd5d-cb97086e3b09
+::  Windows Server 2008 R2: http://www.microsoft.com/downloads/details.aspx?familyid=2dd45bd8-6bcd-47aa-8322-3e10b52b1f1f
+::Open up Windows Powershell with elevated privileges.
+::Set the correct path to the CAB file you’ve downloaded. For example:
+::  $integrationServicesCabPath="C:\Downloads\windows6.2-hypervintegrationservices-x86.cab"
+::Install the patch using the following command:
+::  Add-WindowsPackage -Online -PackagePath $integrationServicesCabPath
+
 goto :exit0
 
 :exit0

--- a/tpl/vagrantfile-eval-win10x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win10x64-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win10x64-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win10x64-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win10x64-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win10x64-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win10x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win10x86-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win10x86-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win10x86-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win10x86-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win10x86-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-datacenter-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-datacenter-ssh.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-datacenter-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-datacenter.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-datacenter.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-standard-ssh.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2008r2-standard.tpl
+++ b/tpl/vagrantfile-eval-win2008r2-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-datacenter-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-datacenter-ssh.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-datacenter-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-datacenter.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-datacenter.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-standard-ssh.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2012r2-standard.tpl
+++ b/tpl/vagrantfile-eval-win2012r2-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2016-standard-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win2016-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2016-standard-ssh.tpl
+++ b/tpl/vagrantfile-eval-win2016-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win2016-standard.tpl
+++ b/tpl/vagrantfile-eval-win2016-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x64-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win7x64-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x64-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win7x64-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win7x86-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x86-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win7x86-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win7x86-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win7x86-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win81x64-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x64-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win81x64-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x64-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win81x64-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-eval-win81x86-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x86-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-eval-win81x86-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-eval-win81x86-enterprise.tpl
+++ b/tpl/vagrantfile-eval-win81x86-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-datacenter-ssh.tpl
+++ b/tpl/vagrantfile-win2008r2-datacenter-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-datacenter.tpl
+++ b/tpl/vagrantfile-win2008r2-datacenter.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-win2008r2-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-enterprise.tpl
+++ b/tpl/vagrantfile-win2008r2-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standard-ssh.tpl
+++ b/tpl/vagrantfile-win2008r2-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standard.tpl
+++ b/tpl/vagrantfile-win2008r2-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standardcore-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-standardcore-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standardcore-ssh.tpl
+++ b/tpl/vagrantfile-win2008r2-standardcore-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-standardcore.tpl
+++ b/tpl/vagrantfile-win2008r2-standardcore.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-web-cygwin.tpl
+++ b/tpl/vagrantfile-win2008r2-web-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-web-ssh.tpl
+++ b/tpl/vagrantfile-win2008r2-web-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2008r2-web.tpl
+++ b/tpl/vagrantfile-win2008r2-web.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2012-datacenter-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-datacenter-ssh.tpl
+++ b/tpl/vagrantfile-win2012-datacenter-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-datacenter.tpl
+++ b/tpl/vagrantfile-win2012-datacenter.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2012-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-standard-ssh.tpl
+++ b/tpl/vagrantfile-win2012-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012-standard.tpl
+++ b/tpl/vagrantfile-win2012-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl
+++ b/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-datacenter-ssh.tpl
+++ b/tpl/vagrantfile-win2012r2-datacenter-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-datacenter.tpl
+++ b/tpl/vagrantfile-win2012r2-datacenter.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2012r2-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standard-ssh.tpl
+++ b/tpl/vagrantfile-win2012r2-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standard.tpl
+++ b/tpl/vagrantfile-win2012r2-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standardcore-cygwin.tpl
+++ b/tpl/vagrantfile-win2012r2-standardcore-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standardcore-ssh.tpl
+++ b/tpl/vagrantfile-win2012r2-standardcore-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2012r2-standardcore.tpl
+++ b/tpl/vagrantfile-win2012r2-standardcore.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2016-standard-cygwin.tpl
+++ b/tpl/vagrantfile-win2016-standard-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2016-standard-ssh.tpl
+++ b/tpl/vagrantfile-win2016-standard-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win2016-standard.tpl
+++ b/tpl/vagrantfile-win2016-standard.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-win7x64-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-enterprise.tpl
+++ b/tpl/vagrantfile-win7x64-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win7x64-pro-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-pro-ssh.tpl
+++ b/tpl/vagrantfile-win7x64-pro-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x64-pro.tpl
+++ b/tpl/vagrantfile-win7x64-pro.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 2048]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl
@@ -39,4 +39,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-win7x86-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-enterprise.tpl
+++ b/tpl/vagrantfile-win7x86-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win7x86-pro-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-pro-ssh.tpl
+++ b/tpl/vagrantfile-win7x86-pro-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win7x86-pro.tpl
+++ b/tpl/vagrantfile-win7x86-pro.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-win81x64-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-enterprise.tpl
+++ b/tpl/vagrantfile-win81x64-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win81x64-pro-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-pro-ssh.tpl
+++ b/tpl/vagrantfile-win81x64-pro-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x64-pro.tpl
+++ b/tpl/vagrantfile-win81x64-pro.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl
+++ b/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-enterprise-ssh.tpl
+++ b/tpl/vagrantfile-win81x86-enterprise-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-enterprise.tpl
+++ b/tpl/vagrantfile-win81x86-enterprise.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-pro-cygwin.tpl
+++ b/tpl/vagrantfile-win81x86-pro-cygwin.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-pro-ssh.tpl
+++ b/tpl/vagrantfile-win81x86-pro-ssh.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/tpl/vagrantfile-win81x86-pro.tpl
+++ b/tpl/vagrantfile-win81x86-pro.tpl
@@ -40,4 +40,9 @@ Vagrant.configure("2") do |config|
     v.customize ["set", :id, "--memsize", 1536]
     v.customize ["set", :id, "--videosize", "256"]
   end
+
+  config.vm.provider :hyperv do |v, override|
+    v.cpus = "1"
+    v.memory = "1536"
+  end
 end

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-datacenter-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-datacenter-cygwin"
     }
   ],
   "post-processors": [

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -119,6 +119,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-datacenter-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-datacenter-ssh"
     }
   ],
   "post-processors": [

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2008r2-datacenter/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-datacenter",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -119,6 +119,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2008r2-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -119,6 +119,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-standard-ssh"
     }
   ],
   "post-processors": [

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2008r2-standard/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-web-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-web-cygwin"
     }
   ],
   "post-processors": [

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -119,6 +119,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2008r2-web-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/disablewinupdate.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-web-ssh"
     }
   ],
   "post-processors": [

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/disablewinupdate.bat",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2008r2-web/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2008r2-web",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -131,6 +131,36 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012-datacenter-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-datacenter-cygwin"
     }
   ],
   "post-processors": [

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -128,6 +128,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012-datacenter-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-datacenter-ssh"
     }
   ],
   "post-processors": [

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -130,6 +130,36 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/unzip.vbs",
+        "floppy/win2012-datacenter/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-datacenter",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -131,6 +131,36 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -128,6 +128,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-standard-ssh"
     }
   ],
   "post-processors": [

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -130,6 +130,36 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/hotfix-KB2842230.bat",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/unzip.vbs",
+        "floppy/win2012-standard/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2012-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-datacenter-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/cygwin.sh",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-datacenter-cygwin"
     }
   ],
   "post-processors": [

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -129,6 +129,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-datacenter-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-datacenter-ssh"
     }
   ],
   "post-processors": [

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -131,6 +131,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2012r2-datacenter/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-datacenter",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -132,6 +132,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -129,6 +129,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standard-ssh"
     }
   ],
   "post-processors": [

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -132,6 +132,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2012r2-standard/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-standardcore-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-standardcore/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standardcore-cygwin"
     }
   ],
   "post-processors": [

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -129,6 +129,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2012r2-standardcore"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2012r2-standardcore/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standardcore-ssh"
     }
   ],
   "post-processors": [

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -131,6 +131,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win2012r2-standardcore/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2012r2-standardcore",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -135,6 +135,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2016-standard-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2016-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.bat",
+        "floppy/cygwin.sh",
+        "floppy/unzip.vbs",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2016-standard-cygwin"
     }
   ],
   "post-processors": [

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -132,6 +132,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win2016-standard-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win2016-standard/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/unzip.vbs",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win2016-standard-ssh"
     }
   ],
   "post-processors": [

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -135,6 +135,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/unzip.vbs",
+        "floppy/win2016-standard/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win2016-standard",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -125,6 +125,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x64-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -122,6 +122,32 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x64-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x64-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -125,6 +125,36 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x64-pro-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-pro-cygwin"
     }
   ],
   "post-processors": [

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x64-pro-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-pro-ssh"
     }
   ],
   "post-processors": [

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x64-pro/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x64-pro",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -125,6 +125,36 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x86-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x86-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x86-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -125,6 +125,36 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x86-pro-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-pro-cygwin"
     }
   ],
   "post-processors": [

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -122,6 +122,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win7x86-pro-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win7x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/networkprompt.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-pro-ssh"
     }
   ],
   "post-processors": [

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -121,6 +121,35 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/networkprompt.bat",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win7x86-pro/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win7x86-pro",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -126,6 +126,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x64-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -123,6 +123,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x64-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -125,6 +125,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win81x64-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -126,6 +126,31 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x64-pro-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-pro-cygwin"
     }
   ],
   "post-processors": [

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -123,6 +123,30 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x64-pro-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-pro-ssh"
     }
   ],
   "post-processors": [

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -125,6 +125,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win81x64-pro/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x64-pro",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -120,6 +120,34 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x86-enterprise-cygwin"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-enterprise-cygwin"
     }
   ],
   "post-processors": [

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -117,6 +117,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x86-enterprise-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-enterprise-ssh"
     }
   ],
   "post-processors": [

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -119,6 +119,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win81x86-enterprise/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-enterprise",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -120,6 +120,35 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x86-pro-cygwin"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/cygwin.sh",
+        "floppy/cygwin.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-pro-cygwin"
     }
   ],
   "post-processors": [

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -117,6 +117,33 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "win81x86-pro-ssh"
+    },
+    {
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/install-winrm.cmd",
+        "floppy/powerconfig.bat",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/openssh.bat",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-pro-ssh"
     }
   ],
   "post-processors": [

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -119,6 +119,34 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
+    },
+    {
+      "communicator": "winrm",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "floppy/00-run-all-scripts.cmd",
+        "floppy/01-install-wget.cmd",
+        "floppy/_download.cmd",
+        "floppy/_packer_config.cmd",
+        "floppy/fixnetwork.ps1",
+        "floppy/install-winrm.cmd",
+        "floppy/passwordchange.bat",
+        "floppy/powerconfig.bat",
+        "floppy/win81x86-pro/Autounattend.xml",
+        "floppy/zz-start-transports.cmd"
+      ],
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{ user `iso_url` }}",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "{{ user `shutdown_command`}}",
+      "type": "hyperv-iso",
+      "vm_name": "win81x86-pro",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "10000s",
+      "winrm_username": "vagrant"
     }
   ],
   "post-processors": [

--- a/wip/win2008r2-standardcore-cygwin.json
+++ b/wip/win2008r2-standardcore-cygwin.json
@@ -33,7 +33,7 @@
         "floppy/cygwin.sh",
         "floppy/passwordchange.bat",
         "floppy/cygwin.bat",
-        "floppy/zz-start-transports.cmd"
+        "floppy/zz-start-transports.cmd",
         "floppy/01-install-powershell.cmd",
         ".windows/provisions/wget.exe"
       ],


### PR DESCRIPTION
I came across this need myself and also found issue #89 talking about this feature as well. I have this at a point where I am successfully building Hyper-V boxes, however I could use some help with an issue I am having and would like input on my changes. In general I would be curious if my changes to the Makefile look good as this is my first interaction with Make let alone working with it.

**Serverspec Test Issue**

I have only built a few boxes so I am looking to use the existing serverspec test to do a quick one over of all the boxes to verify they all build and boot. This caused me to find an issue with running any tests on my machine, but this might be related to my local environment. I am running boxcutter/windows with Make in Powershell 5.1.

I noticed the .sh files in the bin directory which makes me think boxcutter/windows was meant to be ran in *nix or cygwin. Is that the case? If my environment should work then I can give more detail or open an issue for my problem.

If the above is not an issue with my environment then I think that means I will need to make further modifications and potentially recreate the functionality of the bin/*.sh files in Powershell.

I am open to chatting about all this in Slack, etc. if that is more convenient. Thanks!
