### PR TITLE
WIP: Replace http links with https versions or updated versions

### DIFF
--- a/.windows/provisions/Makefile
+++ b/.windows/provisions/Makefile
@@ -1,38 +1,39 @@
 PREDOWNLOADED_FILES=$(wildcard vshell*.*)
 
-CHEF_VERSION?=12.9.38-1
+CHEF_VERSION?=12.22.5
 SALT_VERSION?=2015.8.8-2
-SEVENZIP_VERSION?=1604
-ULTRADEFRAG_VERSION?=7.0.2
-VBOX_VERSION?=5.0.20
+SEVENZIP_VERSION?=1900
+ULTRADEFRAG_VERSION?=7.1.1
+VBOX_VERSION?=5.2.26
+VMWARE_VERSION?=12.5.9/7535481
 
-# always 301's to latest installer:
-#MLSSSH_64_URL?=http://www.mls-software.com/files/setupssh-6.7p1-1-v1.exe
-BITVISE_URL?=https://bvdl.s3-eu-west-1.amazonaws.com/BvSshServer-Inst.exe
-CHEF_64_URL?=https://packages.chef.io/stable/windows/2008r2/chef-client-$(CHEF_VERSION)-x64.msi
-CHEF_32_URL?=https://packages.chef.io/stable/windows/2008r2/chef-client-$(CHEF_VERSION)-x86.msi
-CHEFDK_URL=https://packages.chef.io/stable/windows/2008r2/chefdk-0.13.21-1-x86.msi
+BITVISE_URL?=https://dl.bitvise.com/BvSshServer-Inst.exe
+CHEF_64_URL?=https://packages.chef.io/files/stable/chef/12.22.5/windows/2008r2/chef-client-$(CHEF_VERSION)-x64.msi
+CHEF_32_URL?=https://packages.chef.io/files/stable/chef/12.22.5/windows/2008r2/chef-client-$(CHEF_VERSION)-x86.msi
+CHEFDK_URL=https://packages.chef.io/files/stable/chefdk/0.19.6/windows/2008r2/chefdk-0.19.6-1-x86.msi
 CHOCOLATEY_URL?=https://chocolatey.org/install.ps1
-COREUTILS_URL?=http://downloads.sourceforge.net/gnuwin32/coreutils-5.3.0-bin.zip
-CYGWIN_URL?=http://cygwin.com/setup-x86.exe
-::DOTNET_URL?=http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe
+COREUTILS_URL?=https://downloads.sourceforge.net/gnuwin32/coreutils-5.3.0-bin.zip
+CYGWIN_URL?=https://cygwin.com/setup-x86.exe
+#DOTNET_URL?=https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe
 DOTNET_URL?=https://download.microsoft.com/download/C/3/A/C3A5200B-D33C-47E9-9D70-2F7C65DAAD94/NDP46-KB3045557-x86-x64-AllOS-ENU.exe
 LESSMSI_URL?=https://github.com/activescott/lessmsi/releases/download/v1.4/lessmsi-v1.4.zip
-MLSSSH_32_URL?=http://www.mls-software.com/files/setupssh-7.2p2-1-v1.exe
-NUGET_URL?=http://nuget.org/nuget.exe
+MLSSSH_32_URL?=https://www.mls-software.com/files/setupssh-7.9p1-1.exe
+#MLSSSH_64_URL?=https://www.mls-software.com/files/setupssh-7.9p1-1.exe
+NUGET_URL?=https://dist.nuget.org/win-x86-commandline/v4.9.3/nuget.exe
 PUPPET_32_URL?=https://downloads.puppetlabs.com/windows/puppet-latest.msi
 PUPPET_64_URL?=https://downloads.puppetlabs.com/windows/puppet-x64-latest.msi
 SALT_32_URL?=https://repo.saltstack.com/windows/Salt-Minion-$(SALT_VERSION)-x86-Setup.exe
 SALT_64_URL?=https://repo.saltstack.com/windows/Salt-Minion-$(SALT_VERSION)-AMD64-Setup.exe
-SDELETE_URL?=http://live.sysinternals.com/sdelete.exe
-SEVENZIP_32_URL=http://www.7-zip.org/a/7z$(SEVENZIP_VERSION).msi
-SEVENZIP_64_URL=http://www.7-zip.org/a/7z$(SEVENZIP_VERSION)-x64.msi
-ULTRADEFRAG_32_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-$(ULTRADEFRAG_VERSION).bin.i386.zip
-ULTRADEFRAG_64_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-$(ULTRADEFRAG_VERSION).bin.amd64.zip
-UNXTUTILS_URL?=http://downloads.sourceforge.net/unxutils/UnxUtils.zip
-VAGRANT_PUB_URL?=https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub
-VBOX_ISO_URL=http://download.virtualbox.org/virtualbox/$(VBOX_VERSION)/VBoxGuestAdditions_$(VBOX_VERSION).iso
-VMWARE_TOOLS_TAR_URL=https://softwareupdate.vmware.com/cds/vmw-desktop/ws/12.1.1/3770994/windows/packages/tools-windows.tar
+SDELETE_URL?=https://live.sysinternals.com/sdelete.exe
+SEVENZIP_32_URL=https://www.7-zip.org/a/7z$(SEVENZIP_VERSION).msi
+SEVENZIP_64_URL=https://www.7-zip.org/a/7z$(SEVENZIP_VERSION)-x64.msi
+ULTRADEFRAG_32_URL=https://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-$(ULTRADEFRAG_VERSION).bin.i386.zip
+ULTRADEFRAG_64_URL=https://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-$(ULTRADEFRAG_VERSION).bin.amd64.zip
+UNXTUTILS_URL?=https://downloads.sourceforge.net/unxutils/UnxUtils.zip
+VAGRANT_PUB_URL?=https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub
+VBOX_ISO_URL=https://download.virtualbox.org/virtualbox/$(VBOX_VERSION)/VBoxGuestAdditions_$(VBOX_VERSION).iso
+VMWARE_TOOLS_TAR_URL=https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$(VMWARE_VERSION)/windows/packages/tools-windows.tar
+# See https://www.gnu.org/software/wget/faq.html#Where_can_I_download_Wget.3F
 WGET_URL?=https://eternallybored.org/misc/wget/current/wget.exe
 
 BITVISE:=$(shell basename $(BITVISE_URL))

--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ ssh-$(HYPERV_BOX_DIR)/%$(BOX_SUFFIX): $(HYPERV_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/ssh-box.sh $< hyperv hyperv $(CURRENT_DIR)/test/*_spec.rb
 
 S3_STORAGE_CLASS ?= REDUCED_REDUNDANCY
-S3_ALLUSERS_ID ?= uri=http://acs.amazonaws.com/groups/global/AllUsers
+S3_ALLUSERS_ID ?= uri=https://acs.amazonaws.com/groups/global/AllUsers
 
 s3cp-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	aws s3 cp $< $(VMWARE_S3_BUCKET) --storage-class $(S3_STORAGE_CLASS) --grants full=$(S3_GRANT_ID) read=$(S3_ALLUSERS_ID)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make virtualbox/eval-win7x86-enterprise
 
 ### Tests
 
-The tests are written in [Serverspec](http://serverspec.org) and require the
+The tests are written in [Serverspec](https://serverspec.org) and require the
 `vagrant-serverspec` plugin to be installed with:
 
     vagrant plugin install vagrant-serverspec
@@ -116,11 +116,11 @@ You can also override these setting, such as with
 
 ### Acknowledgments
 
-[Parallels](http://www.parallels.com/) provides a Business Edition license of
+[Parallels](https://www.parallels.com/) provides a Business Edition license of
 their software to run on the basebox build farm.
 
-<img src="http://www.parallels.com/fileadmin/images/corporate/brand-assets/images/logo-knockout-on-red.jpg" width="80">
+<img src="https://www.parallels.com/fileadmin/images/corporate/brand-assets/images/logo-knockout-on-red.jpg" width="80">
 
-[SmartyStreets](http://www.smartystreets.com) is providing basebox hosting for the boxcutter project.
+[SmartyStreets](https://smartystreets.com) is providing basebox hosting for the boxcutter project.
 
 <img src="https://d79i1fxsrar4t.cloudfront.net/images/brand/smartystreets.65887aa3.png" width="320">

--- a/bin/Makefile.local.caroline
+++ b/bin/Makefile.local.caroline
@@ -44,7 +44,7 @@ VIRTUALBOX_BOX_FILES := $(wildcard box/virtualbox/*.box)
 VMWARE_S3_BUCKET := s3://box-cutter/windows/vmware$(VMWARE_VERSION)/
 VIRTUALBOX_S3_BUCKET := s3://box-cutter/windows/virtualbox$(VIRTUALBOX_VERSION)/
 S3_GRANT_ID := id=6efa364c53605afa1f4186b2b23ba97a354e74c7b9238317d9f57bc8f6f6bc5a
-ALLUSERS_ID := uri=http://acs.amazonaws.com/groups/global/AllUsers
+ALLUSERS_ID := uri=https://acs.amazonaws.com/groups/global/AllUsers
 
 upload-s3: upload-s3-vmware upload-s3-virtualbox
 

--- a/bin/Makefile.local.winry
+++ b/bin/Makefile.local.winry
@@ -46,7 +46,7 @@ VIRTUALBOX_BOX_FILES := $(wildcard box/virtualbox/*.box)
 VMWARE_S3_BUCKET := s3://box-cutter/windows/vmware$(VMWARE_VERSION)/
 VIRTUALBOX_S3_BUCKET := s3://box-cutter/windows/virtualbox$(VIRTUALBOX_VERSION)/
 S3_GRANT_ID := id=6efa364c53605afa1f4186b2b23ba97a354e74c7b9238317d9f57bc8f6f6bc5a
-ALLUSERS_ID := uri=http://acs.amazonaws.com/groups/global/AllUsers
+ALLUSERS_ID := uri=https://acs.amazonaws.com/groups/global/AllUsers
 
 upload-s3: upload-s3-vmware upload-s3-virtualbox
 

--- a/bin/upload.sh
+++ b/bin/upload.sh
@@ -16,7 +16,7 @@ VBOX_GUEST_ADDITIONS_VERSION="${VBOX_VERSION%%r*}"
 #VMWARE_VMX_VERSION=$(("${cmd[@]}") 2>&1)
 VMWARE_TOOLS_VERSION="9.6.2"
 
-S3_GRANTS="--grants full=id=${S3_CANONICAL_ID} read=uri=http://acs.amazonaws.com/groups/global/AllUsers"
+S3_GRANTS="--grants full=id=${S3_CANONICAL_ID} read=uri=https://acs.amazonaws.com/groups/global/AllUsers"
 S3_BUCKET_PATH_VMWARE="s3://box-cutter-us-east-1-cloudtrail/windows/vmware${VMWARE_TOOLS_VERSION}/"
 cmd="aws s3 sync ${DIR}/box/vmware/ ${S3_BUCKET_PATH_VMWARE} ${S3_GRANTS}"
 echo ${cmd}

--- a/floppy/00-run-all-scripts.cmd
+++ b/floppy/00-run-all-scripts.cmd
@@ -22,7 +22,7 @@ if exist "%_TEE_CMD%" goto :eof
 set _TEE_CMD=%SystemRoot%\tee.cmd
 set _TEE_JS=%SystemRoot%\tee.js
 
-:: see http://stackoverflow.com/a/10719322/1432614
+:: see https://stackoverflow.com/a/10719322/1432614
 echo var fso = new ActiveXObject("Scripting.FileSystemObject");>"%_TEE_JS%"
 echo var out = fso.OpenTextFile(WScript.Arguments(0),2,true);>>"%_TEE_JS%"
 echo var chr;>>"%_TEE_JS%"

--- a/floppy/_packer_config.cmd
+++ b/floppy/_packer_config.cmd
@@ -1,8 +1,8 @@
 @echo off
 
 :: Uncomment the following to set a different Cygwin mirror
-:: Default: http://mirrors.kernel.org/sourceware/cygwin
-:: set CYGWIN_MIRROR_URL=http://mirrors.kernel.org/sourceware/cygwin
+:: Default: https://mirrors.kernel.org/sourceware/cygwin
+:: set CYGWIN_MIRROR_URL=https://mirrors.kernel.org/sourceware/cygwin
 
 :: Uncomment the following to echo commands as they are run
 :: Default: (unset)

--- a/floppy/bitvisessh.bat
+++ b/floppy/bitvisessh.bat
@@ -5,7 +5,7 @@ SET PACKER_DEBUG=true
 
 title Installing Bitvise SSH Server.  Please wait...
 
-if not defined BITVISE_URL set BITVISE_URL=http://dl.bitvise.com/BvSshServer-Inst.exe
+if not defined BITVISE_URL set BITVISE_URL=https://dl.bitvise.com/BvSshServer-Inst.exe
 
 for %%i in (%BITVISE_URL%) do set BITVISE_EXE=%%~nxi
 set BITVISE_DIR=%TEMP%\bitvise

--- a/floppy/cygwin.bat
+++ b/floppy/cygwin.bat
@@ -15,10 +15,10 @@ if not defined CYGWIN_ARCH (
 )
 
 if not defined CYGWIN_HOME       set CYGWIN_HOME=%SystemDrive%\cygwin
-if not defined CYGWIN_MIRROR_URL set CYGWIN_MIRROR_URL=http://mirrors.kernel.org/sourceware/cygwin
+if not defined CYGWIN_MIRROR_URL set CYGWIN_MIRROR_URL=https://mirrors.kernel.org/sourceware/cygwin
 if not defined CYGWIN_PACKAGES   set CYGWIN_PACKAGES=openssh
 if not defined CYGWIN_TRIES      set CYGWIN_TRIES=3
-if not defined CYGWIN_URL        set CYGWIN_URL=http://cygwin.com/setup-x86.exe
+if not defined CYGWIN_URL        set CYGWIN_URL=https://cygwin.com/setup-x86.exe
 if not defined SSHD_PASSWORD     set SSHD_PASSWORD=D@rj33l1ng
 
 for %%i in ("%CYGWIN_URL%") do set CYGWIN_EXE=%%~nxi

--- a/floppy/eval-win10x64-enterprise/Autounattend.xml
+++ b/floppy/eval-win10x64-enterprise/Autounattend.xml
@@ -39,7 +39,7 @@
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant Administrator</FullName>
                 <Organization>Vagrant Inc.</Organization>
-                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <!-- Product Key from https://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>NPPR9-FWDCX-D2C8J-H872K-2YT43
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>

--- a/floppy/eval-win10x86-enterprise/Autounattend.xml
+++ b/floppy/eval-win10x86-enterprise/Autounattend.xml
@@ -36,7 +36,7 @@
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant Administrator</FullName>
                 <Organization>Vagrant Inc.</Organization>
-                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <!-- Product Key from https://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>NPPR9-FWDCX-D2C8J-H872K-2YT43
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>

--- a/floppy/eval-win2012r2-datacenter/Autounattend.xml
+++ b/floppy/eval-win2012r2-datacenter/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/eval-win2012r2-standard/Autounattend.xml
+++ b/floppy/eval-win2012r2-standard/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/eval-win2016-standard/Autounattend.xml
+++ b/floppy/eval-win2016-standard/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/fixnetwork.ps1
+++ b/floppy/fixnetwork.ps1
@@ -1,9 +1,9 @@
 # You cannot enable Windows PowerShell Remoting on network connections that are set to Public
 # Spin through all the network locations and if they are set to Public, set them to Private
 # using the INetwork interface:
-# http://msdn.microsoft.com/en-us/library/windows/desktop/aa370750(v=vs.85).aspx
+# https://msdn.microsoft.com/en-us/library/windows/desktop/aa370750(v=vs.85).aspx
 # For more info, see:
-# http://blogs.msdn.com/b/powershell/archive/2009/04/03/setting-network-location-to-private.aspx
+# https://blogs.msdn.com/b/powershell/archive/2009/04/03/setting-network-location-to-private.aspx
 
 # Network location feature was only introduced in Windows Vista - no need to bother with this
 # if the operating system is older than Vista

--- a/floppy/install-winrm.cmd
+++ b/floppy/install-winrm.cmd
@@ -5,7 +5,7 @@
 title Enabling Windows Remote Management. Please wait...
 
 echo ==^> Turning off User Account Control (UAC)
-:: see http://www.howtogeek.com/howto/windows-vista/enable-or-disable-uac-from-the-windows-vista-command-line/
+:: see https://www.howtogeek.com/howto/windows-vista/enable-or-disable-uac-from-the-windows-vista-command-line/
 reg ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: reg ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
 
@@ -27,7 +27,7 @@ if errorlevel 1 goto skip_fixnetwork
 if not exist a:\fixnetwork.ps1 echo ==^> ERROR: File not found: a:\fixnetwork.ps1
 
 echo ==^> Setting the Network Location to private
-:: see http://blogs.msdn.com/b/powershell/archive/2009/04/03/setting-network-location-to-private.aspx
+:: see https://blogs.msdn.com/b/powershell/archive/2009/04/03/setting-network-location-to-private.aspx
 powershell -File a:\fixnetwork.ps1 <NUL
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: powershell -File a:\fixnetwork.ps1
 
@@ -97,7 +97,7 @@ netsh advfirewall firewall set rule group="remote administration" new enable=yes
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: netsh advfirewall firewall set rule group="remote administration" new enable=yes
 
 echo ==^> Opening WinRM port 5985 on the firewall
-:: see http://social.technet.microsoft.com/Forums/windowsserver/en-US/a1e65f0f-2550-49ae-aee2-56a9bdcfb8fb/windows-7-remote-administration-firewall-group?forum=winserverManagement
+:: see https://social.technet.microsoft.com/Forums/windowsserver/en-US/a1e65f0f-2550-49ae-aee2-56a9bdcfb8fb/windows-7-remote-administration-firewall-group?forum=winserverManagement
 netsh advfirewall firewall set rule group="Windows Remote Management" new enable=yes
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: netsh advfirewall firewall set rule group="Windows Remote Management" new enable=yes
 

--- a/floppy/openssh.bat
+++ b/floppy/openssh.bat
@@ -4,7 +4,7 @@
 
 title Installing Openssh. Please wait...
 
-if not defined OPENSSH_URL set OPENSSH_URL=http://www.mls-software.com/files/setupssh-7.2p2-1-v1.exe
+if not defined OPENSSH_URL set OPENSSH_URL=https://www.mls-software.com/files/setupssh-7.9p1-1.exe
 if not defined SSHD_PASSWORD  set SSHD_PASSWORD=D@rj33l1ng
 
 for %%i in (%OPENSSH_URL%) do set OPENSSH_EXE=%%~nxi

--- a/floppy/passwordchange.bat
+++ b/floppy/passwordchange.bat
@@ -5,7 +5,7 @@
 title Disabling automatic machine account password changes. Please wait...
 
 echo ==^> Disabling automatic machine account password changes
-:: http://support.microsoft.com/kb/154501
+:: https://support.microsoft.com/kb/154501
 reg add "HKLM\System\CurrentControlSet\Services\Netlogon\Parameters" /v DisablePasswordChange /t REG_DWORD /d 2 /f
 
 :exit0

--- a/floppy/unzip.vbs
+++ b/floppy/unzip.vbs
@@ -1,5 +1,5 @@
-' see http://stackoverflow.com/a/911796/1432614
-' http://stackoverflow.com/a/12718299/1432614
+' see https://stackoverflow.com/a/911796/1432614
+' https://stackoverflow.com/a/12718299/1432614
 
 'If the extraction location does not exist create it.
 Set fso = CreateObject("Scripting.FileSystemObject")

--- a/floppy/win2008r2-datacenter/Autounattend.xml
+++ b/floppy/win2008r2-datacenter/Autounattend.xml
@@ -107,7 +107,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -120,7 +120,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2008r2-enterprise/Autounattend.xml
+++ b/floppy/win2008r2-enterprise/Autounattend.xml
@@ -107,7 +107,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -120,7 +120,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2008r2-standard/Autounattend.xml
+++ b/floppy/win2008r2-standard/Autounattend.xml
@@ -107,7 +107,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -120,7 +120,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2008r2-standardcore/Autounattend.xml
+++ b/floppy/win2008r2-standardcore/Autounattend.xml
@@ -107,7 +107,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -120,7 +120,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2008r2-web/Autounattend.xml
+++ b/floppy/win2008r2-web/Autounattend.xml
@@ -107,7 +107,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -120,7 +120,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2012-datacenter/Autounattend.xml
+++ b/floppy/win2012-datacenter/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
         </component>

--- a/floppy/win2012-standard/Autounattend.xml
+++ b/floppy/win2012-standard/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
         </component>

--- a/floppy/win2012r2-datacenter/Autounattend.xml
+++ b/floppy/win2012r2-datacenter/Autounattend.xml
@@ -108,7 +108,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -121,7 +121,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2012r2-standard/Autounattend.xml
+++ b/floppy/win2012r2-standard/Autounattend.xml
@@ -110,7 +110,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -123,7 +123,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2012r2-standardcore/Autounattend.xml
+++ b/floppy/win2012r2-standardcore/Autounattend.xml
@@ -110,7 +110,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -123,7 +123,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win2016-standard/Autounattend.xml
+++ b/floppy/win2016-standard/Autounattend.xml
@@ -110,7 +110,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -123,7 +123,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win7x64-enterprise/Autounattend.xml
+++ b/floppy/win7x64-enterprise/Autounattend.xml
@@ -104,7 +104,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -118,7 +118,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win7x64-pro/Autounattend.xml
+++ b/floppy/win7x64-pro/Autounattend.xml
@@ -104,7 +104,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>
@@ -118,7 +118,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win7x86-enterprise/Autounattend.xml
+++ b/floppy/win7x86-enterprise/Autounattend.xml
@@ -104,7 +104,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win7x86-pro/Autounattend.xml
+++ b/floppy/win7x86-pro/Autounattend.xml
@@ -104,7 +104,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win81x64-enterprise/Autounattend.xml
+++ b/floppy/win81x64-enterprise/Autounattend.xml
@@ -79,7 +79,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win81x64-pro/Autounattend.xml
+++ b/floppy/win81x64-pro/Autounattend.xml
@@ -79,7 +79,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win81x86-enterprise/Autounattend.xml
+++ b/floppy/win81x86-enterprise/Autounattend.xml
@@ -79,7 +79,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/win81x86-pro/Autounattend.xml
+++ b/floppy/win81x86-pro/Autounattend.xml
@@ -66,7 +66,7 @@
                     <ScopeDefault>true</ScopeDefault>
                     <ScopeDisplayName>Google</ScopeDisplayName>
                     <ScopeKey>Google</ScopeKey>
-                    <ScopeUrl>http://www.google.com/search?q={searchTerms}</ScopeUrl>
+                    <ScopeUrl>https://www.google.com/search?q={searchTerms}</ScopeUrl>
                 </Scope>
             </SearchScopes>
             <DisableAccelerators>true</DisableAccelerators>

--- a/floppy/zzz-debug-log.cmd
+++ b/floppy/zzz-debug-log.cmd
@@ -26,7 +26,7 @@ if exist "%_TEE_CMD%" goto :eof
 set _TEE_CMD=%SystemRoot%\tee.cmd
 set _TEE_JS=%SystemRoot%\tee.js
 
-:: see http://stackoverflow.com/a/10719322/1432614
+:: see https://stackoverflow.com/a/10719322/1432614
 echo var fso = new ActiveXObject("Scripting.FileSystemObject");>"%_TEE_JS%"
 echo var out = fso.OpenTextFile(WScript.Arguments(0),2,true);>>"%_TEE_JS%"
 echo var chr;>>"%_TEE_JS%"

--- a/script/01-install-handle.cmd
+++ b/script/01-install-handle.cmd
@@ -2,7 +2,7 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
-if not defined HANDLE_URL set HANDLE_URL=http://live.sysinternals.com/handle.exe
+if not defined HANDLE_URL set HANDLE_URL=https://live.sysinternals.com/handle.exe
 
 for %%i in ("%HANDLE_URL%") do set HANDLE_EXE=%%~nxi
 set HANDLE_DIR=%TEMP%\handle

--- a/script/clean.bat
+++ b/script/clean.bat
@@ -5,7 +5,7 @@
 pushd "%TEMP%"
 
 :: determine the version of windows since dism in windows 7 lacks cleanup-image
-:: http://stackoverflow.com/questions/13212033/get-windows-version-in-a-batch-file
+:: https://stackoverflow.com/questions/13212033/get-windows-version-in-a-batch-file
 for /f "tokens=4-5 delims=. " %%i in ('ver') do set VERSION=%%i.%%j
 
 if "%VERSION%" == "6.1" (
@@ -36,7 +36,7 @@ echo ==^> Cleaning "%SystemRoot%\TEMP" files >&2
 for %%i in ("%SystemRoot%\TEMP\*.*") do if /i not "%%~nxi" equ "%~nx0" echo del /f /q /s "%%~i"
 
 echo ==^> Removing potentially corrupt recycle bin
-:: see http://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
+:: see https://www.winhelponline.com/blog/fix-corrupted-recycle-bin-windows-7-vista/
 rmdir /q /s %SystemDrive%\$Recycle.bin
 
 echo ==^> Cleaning ISOs in "%USERPROFILE%"

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -127,7 +127,7 @@ if exist "%SystemRoot%\_download.cmd" (
 if not exist "%PUPPET_PATH%" goto exit1
 
 echo ==^> Installing Puppet client %CM_VERSION%
-:: see http://docs.puppetlabs.com/pe/latest/install_windows.html
+:: see https://docs.puppetlabs.com/pe/latest/install_windows.html
 msiexec /qb /i "%PUPPET_PATH%" /l*v "%PUPPET_DIR%\puppet.log" %PUPPET_OPTIONS%
 
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: msiexec /qb /i "%PUPPET_PATH%" /l*v "%PUPPET_DIR%\puppet.log" %PUPPET_OPTIONS%
@@ -167,7 +167,7 @@ if exist "%SystemRoot%\_download.cmd" (
 if not exist "%SALT_PATH%" goto exit1
 
 echo ==^> Installing Salt minion
-:: see http://docs.saltstack.com/en/latest/topics/installation/windows.html
+:: see https://docs.saltstack.com/en/latest/topics/installation/windows.html
 "%SALT_PATH%" /S %SALT_OPTIONS%
 
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: "%SALT_PATH%" /S %SALT_OPTIONS%

--- a/script/sdelete.bat
+++ b/script/sdelete.bat
@@ -2,7 +2,7 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
-if not defined SDELETE_URL set SDELETE_URL=http://web.archive.org/web/20160404120859if_/http://live.sysinternals.com/sdelete.exe
+if not defined SDELETE_URL set SDELETE_URL=https://live.sysinternals.com/sdelete.exe
 
 for %%i in ("%SDELETE_URL%") do set SDELETE_EXE=%%~nxi
 set SDELETE_DIR=%TEMP%\sdelete

--- a/script/ultradefrag.bat
+++ b/script/ultradefrag.bat
@@ -4,11 +4,11 @@
 
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
 
-if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
-if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=http://www.7-zip.org/a/7z1604-x64.msi
+if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=https://7-zip.org/a/7z1604.msi
+if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=https://7-zip.org/a/7z1604-x64.msi
 
-if not defined ULTRADEFRAG_32_URL set ULTRADEFRAG_32_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.i386.zip
-if not defined ULTRADEFRAG_64_URL set ULTRADEFRAG_64_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.amd64.zip
+if not defined ULTRADEFRAG_32_URL set ULTRADEFRAG_32_URL=https://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.i386.zip
+if not defined ULTRADEFRAG_64_URL set ULTRADEFRAG_64_URL=https://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.amd64.zip
 
 goto :main
 

--- a/script/uninstall-7zip.bat
+++ b/script/uninstall-7zip.bat
@@ -2,8 +2,8 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
-if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
-if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=http://www.7-zip.org/a/7z1604-x64.msi
+if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=https://7-zip.org/a/7z1604.msi
+if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=https://7-zip.org/a/7z1604-x64.msi
 
 if defined ProgramFiles(x86) (
   set SEVENZIP_URL=%SEVENZIP_64_URL%

--- a/script/vmtool.bat
+++ b/script/vmtool.bat
@@ -4,9 +4,9 @@
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
-if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
-if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=http://7-zip.org/a/7z1604-x64.msi
-if not defined VBOX_ISO_URL set VBOX_ISO_URL=http://download.virtualbox.org/virtualbox/5.1.30/VBoxGuestAdditions_5.1.30.iso
+if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=https://7-zip.org/a/7z1604.msi
+if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=https://7-zip.org/a/7z1604-x64.msi
+if not defined VBOX_ISO_URL set VBOX_ISO_URL=https://download.virtualbox.org/virtualbox/5.1.30/VBoxGuestAdditions_5.1.30.iso
 if not defined VMWARE_TOOLS_TAR_URL set VMWARE_TOOLS_TAR_URL=https://softwareupdate.vmware.com/cds/vmw-desktop/ws/12.5.5/5234757/windows/packages/tools-windows.tar
 goto main
 
@@ -270,13 +270,13 @@ set GUEST_OS
 if "%GUEST_OS%" == "Windows Server 2016" goto :exit0
 
 ::First, download the appropriate Windows Update CAB file from here: https://support.microsoft.com/en-us/kb/3063109
-::  Windows 8.1: http://www.microsoft.com/downloads/details.aspx?familyid=cd142c42-204a-4566-b767-795e3409b135
-::  Windows 8.1: http://www.microsoft.com/downloads/details.aspx?familyid=3a5a9015-c121-44dd-ad2e-962f66532da7
-::  Windows Server 2012 R2: http://www.microsoft.com/downloads/details.aspx?familyid=a7704851-70bb-46c1-96d2-1b6f7ca226af
-::  Windows Server 2012: http://www.microsoft.com/downloads/details.aspx?familyid=185812c8-8eb5-43c8-8505-70a262f4277d
-::  Windows 7: http://www.microsoft.com/downloads/details.aspx?familyid=54c62651-0fc9-4642-ad12-404b3356825e
-::  Windows 7: http://www.microsoft.com/downloads/details.aspx?familyid=c84f2899-d997-42af-bd5d-cb97086e3b09
-::  Windows Server 2008 R2: http://www.microsoft.com/downloads/details.aspx?familyid=2dd45bd8-6bcd-47aa-8322-3e10b52b1f1f
+::  Windows 8.1: https://www.microsoft.com/downloads/details.aspx?familyid=cd142c42-204a-4566-b767-795e3409b135
+::  Windows 8.1: https://www.microsoft.com/downloads/details.aspx?familyid=3a5a9015-c121-44dd-ad2e-962f66532da7
+::  Windows Server 2012 R2: https://www.microsoft.com/downloads/details.aspx?familyid=a7704851-70bb-46c1-96d2-1b6f7ca226af
+::  Windows Server 2012: https://www.microsoft.com/downloads/details.aspx?familyid=185812c8-8eb5-43c8-8505-70a262f4277d
+::  Windows 7: https://www.microsoft.com/downloads/details.aspx?familyid=54c62651-0fc9-4642-ad12-404b3356825e
+::  Windows 7: https://www.microsoft.com/downloads/details.aspx?familyid=c84f2899-d997-42af-bd5d-cb97086e3b09
+::  Windows Server 2008 R2: https://www.microsoft.com/downloads/details.aspx?familyid=2dd45bd8-6bcd-47aa-8322-3e10b52b1f1f
 ::Open up Windows Powershell with elevated privileges.
 ::Set the correct path to the CAB file you’ve downloaded. For example:
 ::  $integrationServicesCabPath="C:\Downloads\windows6.2-hypervintegrationservices-x86.cab"


### PR DESCRIPTION
Every http link was checked if it was possible to find an https replacement
that works. Every https link should work, except a few things (AWS acs link?)
that do not seem to work even in the http version. Some utilities were update
to newer versions but I tried to keep the major version - to minimize the chance
of breaking builds. Not every combination of image was tested but it is already
a huge step concerning security.

The remaining http links are part of schemas or the LICENSE file and I belive
these should not be changed.