### PR TITLE
Chef workstation and Use Omnitruck API to get Chef URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Makefile.local
 rspec_html_reports
 
 .DS_Store
+
+*.*.json
+floppy/*.*.*
+script/*.*.*

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ WIN81_X64_PRO_CHECKSUM ?= e50a6f0f08e933f25a71fbc843827fe752ed0365
 WIN81_X86_PRO ?= iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso
 WIN81_X86_PRO_CHECKSUM ?= c2d6f5d06362b7cb17dfdaadfb848c760963b254
 
-# Possible values for CM: (nocm | chef | chefdk | salt | puppet)
+# Possible values for CM: (nocm | chef | chefdk | chef-workstation |salt | puppet)
 CM ?= nocm
 # Possible values for CM_VERSION: (latest | x.y.z | x.y)
 CM_VERSION ?=

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ the output of `make list` accordingly.
 Possible values for the CM variable are:
 
 * `nocm` - No configuration management tool
-* `chef` - Install Chef
+* `chef` - Install Chef Client
+* `chefdk` - Install Chef Development Kit
+* `chef-workstation` - Install Chef Workstation
 * `puppet` - Install Puppet
 * `salt`  - Install Salt
 


### PR DESCRIPTION
## Use Omnitruck API to get Chef URLs

* Uses Chefs Omnitruck API to retrieve download URLs based on a product [key](https://github.com/chef/mixlib-install/blob/master/PRODUCT_MATRIX.md) and a semantic version.
* Replaces #87

## Add Chef Workstation as a CM parameter

* Add Chef Workstation 0.2.48 as CM and CM_VERSION parameter.
* Code de-duplication by combining Chef Client, Chef DK, and Chef Workstation downloaders into a single code block that use the above Omnitruck API to retrieve download URLs.

## Additional filename patterns in .gitignore.