### PR TITLE
VirtualBox 6 compatibility fix

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -82,7 +82,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -80,7 +80,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -77,7 +77,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -82,7 +82,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -80,7 +80,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -77,7 +77,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -69,7 +69,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -69,7 +69,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -69,7 +69,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -71,7 +71,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -69,7 +69,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -68,7 +68,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -66,7 +66,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -68,7 +68,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -66,7 +66,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -68,7 +68,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -66,7 +66,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -72,7 +72,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -69,7 +69,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -68,7 +68,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -66,7 +66,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -70,7 +70,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -68,7 +68,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -66,7 +66,7 @@
         [
           "setextradata",
           "{{.Name}}",
-          "VBoxInternal/CPUM/CMPXCHG16B",
+          "VBoxInternal/CPUM/IsaExts/CMPXCHG16B",
           "1"
         ]
       ],


### PR DESCRIPTION
Fix:
Error starting VM: VBoxManage error: VBoxManage: error: Duplicate
config values '/CPUM/CMPXCHG16B' and '/CPUM/IsaExts/CMPXCHG16B' - please
remove the former! (VERR_DUPLICATE)

/CPUM/CMPXCHG16B was deprecated at least in 2015 and removed in
VirtualBox 6.