### PR TITLE
Install Salt using Salt bootstrap script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ else
 endif
 # Packer does not allow empty variables, so only pass variables that are defined
 PACKER_VARS := -var 'cm=$(CM)' -var 'version=$(BOX_VERSION)' -var 'update=$(UPDATE)' -var 'headless=$(HEADLESS)' -var "shutdown_command=$(SHUTDOWN_COMMAND)"
+ifdef CM_OPTIONS
+	PACKER_VARS += -var 'cm_options=$(CM_OPTIONS)'
+endif
 ifdef CM_VERSION
 	PACKER_VARS += -var 'cm_version=$(CM_VERSION)'
 endif

--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ Possible values for the CM variable are:
 * `puppet` - Install Puppet
 * `salt`  - Install Salt
 
-You can also specify a variable `CM_VERSION`, if supported by the
-configuration management tool, to override the default of `latest`.
+You can also specify a variable `CM_VERSION` for all configuration management
+tools except Salt, to override the default of `latest`.
 The value of `CM_VERSION` should have the form `x.y` or `x.y.z`,
 such as `CM_VERSION := 11.12.4`
+
+For Salt you can specify a variable `CM_OPTIONS`. This variable will be passed
+to Salt bootstrap script. For information on possible values please read:
+https://github.com/saltstack/salt-bootstrap/blob/stable/bootstrap-salt.ps1
 
 Another use for `Makefile.local` is to override the default locations
 for the Windows install ISO files.

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -171,6 +171,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -167,6 +167,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -167,6 +167,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -171,6 +171,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -167,6 +167,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -167,6 +167,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -145,6 +145,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -139,39 +139,20 @@ goto exit0
 :salt
 ::::::::::::
 
-if "%CM_VERSION%" == "latest" set CM_VERSION=2015.8.8-2
-
-if not defined SALT_64_URL set SALT_64_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-AMD64-Setup.exe
-if not defined SALT_32_URL set SALT_32_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-x86-Setup.exe
-
-if defined ProgramFiles(x86) (
-  set SALT_URL=%SALT_64_URL%
-) else (
-  set SALT_URL=%SALT_32_URL%
-)
-
-for %%i in ("%SALT_URL%") do set SALT_EXE=%%~nxi
 set SALT_DIR=%TEMP%\salt
-set SALT_PATH=%SALT_DIR%\%SALT_EXE%
-
 echo ==^> Creating "%SALT_DIR%"
 mkdir "%SALT_DIR%"
 pushd "%SALT_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%SALT_URL%" "%SALT_PATH%"
-) else (
-  echo ==^> Downloading %SALT_URL% to %SALT_PATH%
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_PATH%')" <NUL
-)
+set SALT_URL=https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.ps1
+set SALT_PATH=%SALT_DIR%\bootstrap-salt.ps1
+echo ==^> Downloading %SALT_URL% to %SALT_PATH%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_PATH%')" <NUL
+
 if not exist "%SALT_PATH%" goto exit1
 
 echo ==^> Installing Salt minion
-:: see http://docs.saltstack.com/en/latest/topics/installation/windows.html
-"%SALT_PATH%" /S %SALT_OPTIONS%
-
-@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: "%SALT_PATH%" /S %SALT_OPTIONS%
-ver>nul
+powershell "%SALT_PATH%" %CM_OPTIONS%
 
 goto exit0
 

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -153,6 +153,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -150,6 +150,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -153,6 +153,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -159,6 +159,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -141,6 +141,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -144,6 +144,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -135,6 +135,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -135,6 +135,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -138,6 +138,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],


### PR DESCRIPTION
Official bootstrap script written in Powershell is used.
`CM_OPTIONS` are passed as arguments (see `README.md`).

PS: the old way of installing Salt was limited and no longer works.