### PR TITLE
Added the output_directory user variable for allowing the user to control where the box is emitted

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -163,7 +163,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-cygwin.tpl"
     }

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -209,6 +209,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -205,6 +205,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-ssh.tpl"
     }

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -197,6 +197,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise.tpl"
     }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -163,7 +163,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-cygwin.tpl"
     }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -209,6 +209,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-ssh.tpl"
     }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -205,6 +205,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win10x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win10x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise.tpl"
     }

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -197,6 +197,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-cygwin.tpl"
     }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-ssh.tpl"
     }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -180,6 +180,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter.tpl"
     }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -176,6 +176,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-cygwin.tpl"
     }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -176,6 +176,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-ssh.tpl"
     }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -172,6 +172,7 @@
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard.tpl"
     }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-cygwin.tpl"
     }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -197,6 +197,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -193,6 +193,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-ssh.tpl"
     }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter.tpl"
     }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -189,6 +189,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-cygwin.tpl"
     }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -197,6 +197,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -193,6 +193,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-ssh.tpl"
     }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -189,6 +189,7 @@
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard.tpl"
     }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/eval-win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-cygwin.tpl"
     }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -197,6 +197,7 @@
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/eval-win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-ssh.tpl"
     }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -193,6 +193,7 @@
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/eval-win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard.tpl"
     }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -189,6 +189,7 @@
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
     }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -188,6 +188,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-ssh.tpl"
     }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -188,6 +188,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -180,6 +180,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise.tpl"
     }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -188,6 +188,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-cygwin.tpl"
     }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-ssh.tpl"
     }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -183,6 +183,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -176,6 +176,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise.tpl"
     }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -189,6 +189,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-cygwin.tpl"
     }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -189,6 +189,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-ssh.tpl"
     }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -185,6 +185,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise.tpl"
     }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-cygwin.tpl"
     }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -189,6 +189,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -185,6 +185,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -139,7 +139,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-ssh.tpl"
     }

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/eval-win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise.tpl"
     }

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -181,6 +181,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl"
     }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-ssh.tpl"
     }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter.tpl"
     }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl"
     }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-ssh.tpl"
     }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise.tpl"
     }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-cygwin.tpl"
     }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-ssh.tpl"
     }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard.tpl"
     }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-web-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-web-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-cygwin.tpl"
     }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-web-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-web-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-ssh.tpl"
     }

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2008r2-web-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2008r2-web-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web.tpl"
     }

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-cygwin.tpl"
     }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -192,6 +192,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-ssh.tpl"
     }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -188,6 +188,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -183,6 +183,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter.tpl"
     }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -148,7 +148,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-cygwin.tpl"
     }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -194,6 +194,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-ssh.tpl"
     }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -188,6 +188,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -183,6 +183,7 @@
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard.tpl"
     }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl"
     }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -193,6 +193,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-ssh.tpl"
     }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -189,6 +189,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter.tpl"
     }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -184,6 +184,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -192,6 +192,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-cygwin.tpl"
     }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -189,6 +189,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-ssh.tpl"
     }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard.tpl"
     }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -184,6 +184,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standardcore-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standardcore-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore-cygwin.tpl"
     }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -193,6 +193,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -189,6 +189,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -184,6 +184,7 @@
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -197,6 +197,7 @@
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-cygwin.tpl"
     }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -193,6 +193,7 @@
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-ssh.tpl"
     }

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "box/{{.Provider}}/win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard.tpl"
     }

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -189,6 +189,7 @@
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl"
     }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -183,6 +183,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-ssh.tpl"
     }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -179,6 +179,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -171,6 +171,7 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise.tpl"
     }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -183,6 +183,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-cygwin.tpl"
     }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -179,6 +179,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-ssh.tpl"
     }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro.tpl"
     }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl"
     }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -183,6 +183,7 @@
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -179,6 +179,7 @@
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-ssh.tpl"
     }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise.tpl"
     }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-cygwin.tpl"
     }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -183,6 +183,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -179,6 +179,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-ssh.tpl"
     }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win7x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win7x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro.tpl"
     }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -171,6 +171,7 @@
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -184,6 +184,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl"
     }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-ssh.tpl"
     }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise.tpl"
     }

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -184,6 +184,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-cygwin.tpl"
     }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-ssh.tpl"
     }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -180,6 +180,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro.tpl"
     }

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -176,6 +176,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -177,6 +177,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -131,7 +131,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl"
     }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -173,6 +173,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -127,7 +127,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-ssh.tpl"
     }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise.tpl"
     }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -168,6 +168,7 @@
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -131,7 +131,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-cygwin.tpl"
     }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -177,6 +177,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -127,7 +127,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-ssh.tpl"
     }

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -173,6 +173,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -168,6 +168,7 @@
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "output_directory": "box/{{.Provider}}"
   }
 }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/win81x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `output_directory` }}/win81x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro.tpl"
     }


### PR DESCRIPTION
This PR adds a new user variable "output_directory" to all the templates, and uses it in the "output" key of the "post-processors" section. This allows the template user to specify which directory the resulting .box file will get written to. The default value for the "output_directory" is set to the original path based on the provider so that the original semantics are still preserved.