### PR TITLE
Fixed a couple of the templates where the hyperv-iso builder got mixed up with the post-processors

### DIFF
--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -105,15 +105,6 @@
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
       "vm_name": "eval-win7x64-enterprise-cygwin"
-    }
-  ],
-  "post-processors": [
-    {
-      "compression_level": 1,
-      "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
-      "type": "vagrant",
-      "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -144,8 +135,16 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x64-enterprise-cygwin",
-      "vagrantfile_template": "{{template_dir}}/"
+      "vm_name": "eval-win7x64-enterprise-cygwin"
+    }
+  ],
+  "post-processors": [
+    {
+      "compression_level": 1,
+      "keep_input_artifact": false,
+      "output": "box/{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
     }
   ],
   "provisioners": [

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -111,15 +111,6 @@
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
-    }
-  ],
-  "post-processors": [
-    {
-      "compression_level": 1,
-      "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
-      "type": "vagrant",
-      "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise.tpl"
     },
     {
       "communicator": "winrm",
@@ -149,8 +140,16 @@
       "vm_name": "eval-win81x64-enterprise",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
-      "winrm_username": "vagrant",
-      "vagrantfile_template": "{{template_dir}}/"
+      "winrm_username": "vagrant"
+    }
+  ],
+  "post-processors": [
+    {
+      "compression_level": 1,
+      "keep_input_artifact": false,
+      "output": "box/{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise.tpl"
     }
   ],
   "provisioners": [

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -127,6 +127,8 @@
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
       "type": "hyperv-iso",
       "vm_name": "win7x64-enterprise-cygwin"
     }


### PR DESCRIPTION
@dragon788 noticed that there were a few templates where the hyperv-iso builder somehow worked its way into the post-processors. Since it's a builder (and not a post-processor), this resulted in the templates being unable to be validated, and really the templates were just busted.

This PR fixes the two templates that I found with this issue, and also fixed a bunk schema validation in the win7x64-enterprise-cygwin.json template.

This closes PR #192.