### PR TITLE
Remove usage of the "ssh_wait_timeout" key from the hyperv-iso builders

### DIFF
--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -129,7 +129,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x64-pro-cygwin"
     }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -125,7 +125,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x64-pro-ssh"
     }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -129,7 +129,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x86-enterprise-cygwin"
     }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -125,7 +125,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x86-enterprise-ssh"
     }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -129,7 +129,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x86-pro-cygwin"
     }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -125,7 +125,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win7x86-pro-ssh"
     }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -130,7 +130,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win81x64-enterprise-cygwin"
     }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -126,7 +126,6 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
       "type": "hyperv-iso",
       "vm_name": "win81x64-enterprise-ssh"
     }


### PR DESCRIPTION
It seems that packer 1.5.1 doesn't support the "ssh_wait_timeout" key in the hyperv-iso builder. This results in Packer not being able to build some of the templates. It's very weird to me that this key isn't supported by the hyperv-iso builder and it smells like a Packer bug.

However, there's no open tickets for this so maybe it was done on purpose. Nonetheless, I collected these into their own PR so that when/if Packer re-introduces this key we can simply revert this PR.

This closes issue #194.