### PR TITLE
Added missing keys to a handful of templates

### DIFF
--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -123,6 +123,8 @@
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
       "type": "hyperv-iso",
       "vm_name": "win7x64-enterprise-ssh"
     }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -128,6 +128,8 @@
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
       "type": "hyperv-iso",
       "vm_name": "win81x64-pro-cygwin"
     }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -124,6 +124,8 @@
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
       "type": "hyperv-iso",
       "vm_name": "win81x64-pro-ssh"
     }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -99,7 +99,6 @@
       "vm_name": "win81x86-pro-cygwin"
     },
     {
-      "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [


### PR DESCRIPTION
A couple of templates were missing the ssh_username and ssh_password pair in the hyperv-iso builder. This adds them to the specified templates so that they'll validate and build properly. The win81x86-pro-cygwin template also had the communicator mis-set to "winrm". This PR also fixes that by removing the communicator which should result in packer falling back to ssh.

This closes PR #196.