### PR TITLE
Fixed the definition of the "memory" user variable in the win2016-standard-*.json templates

### DIFF
--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -92,7 +92,6 @@
         "{{template_dir}}/floppy/zz-start-transports.cmd"
       ],
       "guest_os_type": "win-2012",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
       "iso_url": "{{ user `iso_url` }}",

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -185,7 +185,7 @@
   ],
   "variables": {
     "cpus": "2",
-    "memory": "{{ user `memory` }}",
+    "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
     "cm_version": "",

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -181,7 +181,7 @@
   ],
   "variables": {
     "cpus": "2",
-    "memory": "{{ user `memory` }}",
+    "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
     "cm_version": "",


### PR DESCRIPTION
The win2016-standard-*.json templates had mistakenly used a template variable to define the default value of the "memory" user variable. As template variables can't be used in the definition of user variables, this resulted in the default value for the "memory" variable to be empty. All-in all this results in a failure to validate these templates and requires a user to define the user variable when building.

This PR sets the default value of this user variable to the common value "2048" used by the other win2016-standard templates.

Another thing that this PR fixes is that in the win2012r2-standard.json template the "headless" key is used in the parallels-iso builder. This isn't a valid keyword in the schema from Packer 1.5.1. As a result, this was removed so that template will now validate properly.

This closes issue #198.