### PR TITLE
Updated installing salt with its bootstrap script, and enabled specifying the CM_OPTIONS for all the configuration management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ version is to be used for build. This is commonly used to provide
 compatibility with newer versions of VMware Workstation. For example,
 you may indicate version 14 of Workstation: `HW_VERSION := 14`.
 
-For Salt you can specify a variable `CM_OPTIONS`. This variable will be passed
-to Salt bootstrap script. For information on possible values please read:
-https://github.com/saltstack/salt-bootstrap/blob/stable/bootstrap-salt.ps1
+For configuration management tools (such as Salt), you can specify a
+variable `CM_OPTIONS`. This variable will be passed to the installer for
+the configuration management tool. For information on possible values
+please read the documentation for the respective configuration management
+tool.
 
 Another use for `Makefile.local` is to override the default locations
 for the Windows install ISO files.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Possible values for the CM variable are:
 * `puppet` - Install Puppet
 * `salt`  - Install Salt
 
-You can also specify a variable `CM_VERSION`, if supported by the
-configuration management tool, to override the default of `latest`.
+You can also specify a variable `CM_VERSION` for all configuration management
+tools except Salt, to override the default of `latest`.
 The value of `CM_VERSION` should have the form `x.y` or `x.y.z`,
 such as `CM_VERSION := 11.12.4`
 
@@ -86,6 +86,10 @@ It is also possible to specify a `HW_VERSION` if a specific hardware
 version is to be used for build. This is commonly used to provide
 compatibility with newer versions of VMware Workstation. For example,
 you may indicate version 14 of Workstation: `HW_VERSION := 14`.
+
+For Salt you can specify a variable `CM_OPTIONS`. This variable will be passed
+to Salt bootstrap script. For information on possible values please read:
+https://github.com/saltstack/salt-bootstrap/blob/stable/bootstrap-salt.ps1
 
 Another use for `Makefile.local` is to override the default locations
 for the Windows install ISO files.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ Possible values for the CM variable are:
 * `salt`  - Install Salt
 
 You can also specify a variable `CM_VERSION` for all configuration management
-tools except Salt, to override the default of `latest`.
-The value of `CM_VERSION` should have the form `x.y` or `x.y.z`,
-such as `CM_VERSION := 11.12.4`
+tools to override the default of `latest`. The value of `CM_VERSION` should
+have the form `x.y` or `x.y.z`, such as `CM_VERSION := 11.12.4`
 
 It is also possible to specify a `HW_VERSION` if a specific hardware
 version is to be used for build. This is commonly used to provide

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -3,16 +3,14 @@
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
 :: Get the PlatformVersion from SystemInfo
-for /f "delims=:; tokens=1,2" %a in ('systeminfo') do (
-  if "%a" == "OS Version" (
-    for /f %v in ("%b") do set PlatformVersionRow=%v
-  )
+for /f "delims=:; tokens=1,2" %%a in ('systeminfo') do (
+  if "%%a" == "OS Version" set PlatformVersionRow=%%b
 )
 
 :: Extract the major/minor version
-for /f "delims=.; tokens=1,2" %a in ("%PlatformVersionRow%") do (
-  set PlatformVersionMajor=%a
-  set PlatformVersionMinor=%b
+for /f "delims=.; tokens=1,2" %%a in ("%PlatformVersionRow%") do (
+  set PlatformVersionMajor=%%a
+  set PlatformVersionMinor=%%b
 )
 
 :: Set some reasonable defaults

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -13,6 +13,8 @@ for /f "delims=.; tokens=1,2" %%a in ("%PlatformVersionRow%") do (
   for /f "tokens=*" %%v in ("%%b") do set PlatformVersionMinor=%%v
 )
 
+echo ==^> Detected Windows Platform Version: %PlatformVersionMajor%.%PlatformVersionMinor%
+
 :: Set some reasonable defaults
 if not defined TEMP set TEMP=%LOCALAPPDATA%\Temp
 
@@ -184,7 +186,8 @@ pushd "%SALT_DIR%"
 
 :: If we're on a platform where salt-bootstrap is buggy, then fall back to just
 :: using the regular salt-repository method.
-if "%PlatformVersionMajor%" == "6" goto saltrepository
+if "%PlatformVersionMajor%" == "6" if "%PlatformVersionMinor%" == "0" goto saltrepository
+if "%PlatformVersionMajor%" == "6" if "%PlatformVersionMinor%" == "1" goto saltrepository
 
 ::::::::::::
 :saltbootstrap

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -161,39 +161,20 @@ goto exit0
 ::::::::::::
 if not defined SALT_OPTIONS set SALT_OPTIONS=%CM_OPTIONS%
 
-if "%CM_VERSION%" == "latest" set CM_VERSION=2015.8.8-2
-
-if not defined SALT_64_URL set SALT_64_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-AMD64-Setup.exe
-if not defined SALT_32_URL set SALT_32_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-x86-Setup.exe
-
-if defined ProgramFiles(x86) (
-  set SALT_URL=%SALT_64_URL%
-) else (
-  set SALT_URL=%SALT_32_URL%
-)
-
-for %%i in ("%SALT_URL%") do set SALT_EXE=%%~nxi
 set SALT_DIR=%TEMP%\salt
-set SALT_PATH=%SALT_DIR%\%SALT_EXE%
-
 echo ==^> Creating "%SALT_DIR%"
 mkdir "%SALT_DIR%"
 pushd "%SALT_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%SALT_URL%" "%SALT_PATH%"
-) else (
-  echo ==^> Downloading %SALT_URL% to %SALT_PATH%
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_PATH%')" <NUL
-)
+set SALT_URL=https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.ps1
+set SALT_PATH=%SALT_DIR%\bootstrap-salt.ps1
+echo ==^> Downloading %SALT_URL% to %SALT_PATH%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_PATH%')" <NUL
+
 if not exist "%SALT_PATH%" goto exit1
 
 echo ==^> Installing Salt minion
-:: see http://docs.saltstack.com/en/latest/topics/installation/windows.html
-"%SALT_PATH%" /S %SALT_OPTIONS%
-
-@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: "%SALT_PATH%" /S %SALT_OPTIONS%
-ver>nul
+powershell "%SALT_PATH%" %CM_OPTIONS%
 
 goto exit0
 

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -175,8 +175,6 @@ goto exit0
 :salt
 ::::::::::::
 if not defined SALT_OPTIONS set SALT_OPTIONS=%CM_OPTIONS%
-
-if "%CM_VERSION%" == "latest" set CM_VERSION=2019.2.2
 if not defined SALT_REVISION set SALT_REVISION=stable
 
 set SALT_DIR=%TEMP%\salt
@@ -191,6 +189,9 @@ if "%PlatformVersionMajor%" == "6" goto saltrepository
 ::::::::::::
 :saltbootstrap
 ::::::::::::
+
+:: We hardcode the CM_VERSION here to workaround saltstack/salt-bootstrap#1394
+if "%CM_VERSION%" == "latest" set CM_VERSION=2019.2.2
 
 set SALT_URL=http://raw.githubusercontent.com/saltstack/salt-bootstrap/%SALT_REVISION%/bootstrap-salt.ps1
 
@@ -231,9 +232,9 @@ if not defined SALT_ARCH (
 )
 
 if "%CM_VERSION%" == "latest" (
-  set SALT_URL=https://repo.saltstack.com/windows/Salt-Minion-Latest-%SALT_PYTHONVERSION%-%SALT_ARCH%-Setup.exe
+  set SALT_URL=http://repo.saltstack.com/windows/Salt-Minion-Latest-%SALT_PYTHONVERSION%-%SALT_ARCH%-Setup.exe
 ) else (
-  set SALT_URL=https://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-%SALT_PYTHONVERSION%-%SALT_ARCH%-Setup.exe
+  set SALT_URL=http://repo.saltstack.com/windows/Salt-Minion-%CM_VERSION%-%SALT_PYTHONVERSION%-%SALT_ARCH%-Setup.exe
 )
 
 set SALT_PATH=%SALT_DIR%\Salt-Minion-Setup.exe

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -211,6 +211,9 @@ if "%CM_VERSION%" == "latest" (
   powershell "%SALT_PATH%" -version "%CM_VERSION%" %SALT_OPTIONS%
 )
 
+@if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: "%SALT_PATH%" -version "%CM_VERSION%" %SALT_OPTIONS%
+ver>nul
+
 goto exit0
 
 ::::::::::::

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -2,10 +2,24 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+:: Get the PlatformVersion from SystemInfo
+for /f "delims=:; tokens=1,2" %a in ('systeminfo') do (
+  if "%a" == "OS Version" (
+    for /f %v in ("%b") do set PlatformVersionRow=%v
+  )
+)
+
+:: Extract the major/minor version
+for /f "delims=.; tokens=1,2" %a in ("%PlatformVersionRow%") do (
+  set PlatformVersionMajor=%a
+  set PlatformVersionMinor=%b
+)
+
+:: Set some reasonable defaults
 if not defined TEMP set TEMP=%LOCALAPPDATA%\Temp
 
+:: Figure out which configuration management tool to use
 if not defined CM echo ==^> ERROR: The "CM" variable was not found in the environment & goto exit1
-
 if "%CM%" == "nocm"   goto nocm
 
 if not defined CM_VERSION (

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -7,10 +7,10 @@ for /f "delims=:; tokens=1,2" %%a in ('systeminfo') do (
   if "%%a" == "OS Version" set PlatformVersionRow=%%b
 )
 
-:: Extract the major/minor version
+:: Extract the major/minor version (stripped)
 for /f "delims=.; tokens=1,2" %%a in ("%PlatformVersionRow%") do (
-  set PlatformVersionMajor=%%a
-  set PlatformVersionMinor=%%b
+  for /f "tokens=*" %%v in ("%%a") do set PlatformVersionMajor=%%v
+  for /f "tokens=*" %%v in ("%%b") do set PlatformVersionMinor=%%v
 )
 
 :: Set some reasonable defaults

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -174,7 +174,11 @@ powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%'
 if not exist "%SALT_PATH%" goto exit1
 
 echo ==^> Installing Salt minion
-powershell "%SALT_PATH%" %CM_OPTIONS%
+if "%CM_VERSION%" == "latest" (
+  powershell "%SALT_PATH%" %SALT_OPTIONS%
+) else (
+  powershell "%SALT_PATH%" -version "%CM_VERSION%" %SALT_OPTIONS%
+)
 
 goto exit0
 


### PR DESCRIPTION
This PR is based on PR #182, and supersedes it. The original intent of the PR is to fix the installation of the SaltStack configuration management tool. Originally we were hardcoding the path to the SaltStack minion url, dowloading, and then installing it. Since then SaltStack has introduced a bootstrap script (https://github.com/saltstack/salt-bootstrap) to install a minion which is used by this PR to automatically determine the url of the correct package to install.

The original PR introduced a new option, `CM_OPTIONS`, that allows the user to customize the options for SaltStack. It was discovered that in `script/cmtool.bat`, all of the configuration tools use their own variable for passing options to their installer (i.e. PUPPET_OPTIONS, CHEF_OPTIONS, etc).

Despite their available, they have each been left undefined. As it seems that passing options to each of these was intended, this PR extends the `CM_OPTIONS` capability to each of the configuration management tools. This allows the user to explicitly control the options if they so desire.

It should also be mentioned that all of our templates have been modified to support the `CM_OPTIONS` environment variable. (This is why this PR touches so many files).