### PR TITLE
Add CM_LICENSED and restore backward compatibility to use free Chef components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,21 @@ ifndef CM_VERSION
 		CM_VERSION = latest
 	endif
 endif
+
+CM_LICENSED ?=
+ifndef CM_LICENSED
+	ifeq ($(CM),chef)
+		CM_LICENSED = false
+	endif
+
+	ifeq ($(CM),chefdk)
+	  CM_LICENSED = false
+	endif
+
+	ifeq ($(CM),chef-workstation)
+		CM_LICENSED = false
+	endif
+endif
 BOX_VERSION ?= $(shell cat VERSION)
 UPDATE ?= false
 GENERALIZE ?= false
@@ -96,6 +111,9 @@ ifdef HW_VERSION
 endif
 ifdef CM_VERSION
 	PACKER_VARS += -var 'cm_version=$(CM_VERSION)'
+endif
+ifdef CM_LICENSED
+	PACKER_VARS += -var 'cm_licensed=$(CM_LICENSED)'
 endif
 ON_ERROR ?= cleanup
 PACKER ?= packer

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ configuration management tool, to override the default of `latest`.
 The value of `CM_VERSION` should have the form `x.y` or `x.y.z`,
 such as `CM_VERSION := 11.12.4`
 
+The latest Chef products are governed by a non-free license and require license
+acceptance.  To support using both free and licensed Chef products a new
+variable `CM_LICENSED` defaults to `'false'`.  If `CM_VERSION=latest` and
+`CM_LICENSED=false` then the latest free version of the `CM` will be used.
+
 It is also possible to specify a `HW_VERSION` if a specific hardware
 version is to be used for build. This is commonly used to provide
 compatibility with newer versions of VMware Workstation. For example,

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -172,6 +172,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -200,6 +201,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -196,6 +197,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -172,6 +172,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -200,6 +201,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -196,6 +197,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -163,6 +164,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -179,6 +180,7 @@
     "memory": "3072",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -179,6 +180,7 @@
     "memory": "3072",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "3072",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -179,6 +180,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -176,6 +177,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -148,6 +148,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -176,6 +177,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -172,6 +173,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -44,6 +44,19 @@ if "%CM%" == "chef" (
 
 :: Deterine the other desired parameters here
 if not defined OMNITRUCK_PLATFORM set OMNITRUCK_PLATFORM=windows
+if not defined CM_LICENSED set CM_LICENSED=false
+
+if "%CM_VERSION%" == "latest" if "%CM_LICENSED%" == "false" (
+    echo ==^> Overriding 'CM_VERSION=latest' to the latest supported free version because CM_LICENSED=false
+    if "%OMNITRUCK_PRODUCT%" == "chef-workstation" (
+        set CM_VERSION=0.3.2
+    ) else if "%OMNITRUCK_PRODUCT%" == "chefdk" (
+        set CM_VERSION=3.12.10
+    ) else if "%OMNITRUCK_PRODUCT%" == "chef" (
+        set CM_VERSION=14.14.29
+    )
+)
+
 if not defined OMNITRUCK_VERSION set OMNITRUCK_VERSION=%CM_VERSION%
 
 if not defined OMNITRUCK_MACHINE_ARCH (

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -183,6 +184,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -179,6 +180,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -157,6 +157,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -185,6 +186,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -179,6 +180,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -175,6 +176,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -183,6 +184,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -175,6 +176,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -175,6 +176,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -188,6 +189,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -184,6 +185,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -180,6 +181,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -170,6 +171,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -170,6 +171,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -170,6 +171,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -174,6 +175,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -170,6 +171,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -162,6 +163,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -175,6 +176,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -175,6 +176,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -171,6 +172,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -167,6 +168,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -168,6 +169,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -136,6 +136,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -164,6 +165,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -159,6 +160,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -168,6 +169,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -136,6 +136,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -164,6 +165,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_LICENSED={{user `cm_licensed`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],
@@ -159,6 +160,7 @@
     "memory": "2048",
     "guest_additions_url": "",
     "cm": "chef",
+    "cm_licensed": "",
     "cm_version": "",
     "hw_version": "7",
     "disk_size": "40960",


### PR DESCRIPTION
Ready to merge.

### Adds

*  `make` parameter `CM_LICENSED=true|false`.
   * Defaults to `false` if `CM == [chef|chefdk|chef-workstation]`
   * Defaults to `''` if `CM != [chef|chefdk|chef-workstation]`
* Edited `script/cmtool.bat` to use `CM_LICENSED`
  * If `CM == [chef|chefdk|chef-workstation] && CM_LICENSED == false && CM_VERSION == latest` then `CM_VERSION=latest` is overridden to the highest free version of `CM`
  * If `CM == [chef|chefdk|chef-workstation] && CM_LICENSED == true && CM_VERSION == latest` then `CM_VERSION=latest` is used by Omnitruck to get the latest version of `CM`
* Edited all json templates using a script to add `cm_licensed`

### Usage
* Command `make CM=chef virtualbox/eval-win7x64-enterprise `

  ```
  ==> virtualbox-iso: Provisioning with shell script: /Users/ba13509/repos/bbb_github/pipedream/boxcutter_windows/script/cmtool.bat
    virtualbox-iso: ==> Overriding CM_VERSION=latest to supported free version because CM_LICENSED=false
    virtualbox-iso: ==> Getting chef 14.14.29 x64 download URL
    virtualbox-iso: "==> Using Chef Omnitruck API URL: "https://omnitruck.chef.io/stable/chef/metadata?p=windows&m=x64&v=14.14.29""
    virtualbox-iso: "==> Got chef download URL: https://packages.chef.io/files/stable/chef/14.14.29/windows/2019/chef-client-14.14.29-1-x64.msi"
    virtualbox-iso: ==> Creating "C:\Users\vagrant\AppData\Local\Temp\chef"
    virtualbox-iso: ==> Downloading "https://packages.chef.io/files/stable/chef/14.14.29/windows/2019/chef-client-14.14.29-1-x64.msi" to "C:\Users\vagrant\AppData\Local\Temp\chef\chef-client-14.14.29-1-x64.msi"
  ```
* Command `make CM=chef virtualbox/eval-win7x64-enterprise CM_LICENSED=true`

  ```
  ==> virtualbox-iso: Provisioning with shell script: /Users/ba13509/repos/bbb_github/pipedream/boxcutter_windows/script/cmtool.bat
    virtualbox-iso: ==> Getting chef latest x64 download URL
    virtualbox-iso: "==> Using Chef Omnitruck API URL: "https://omnitruck.chef.io/stable/chef/metadata?p=windows&m=x64&v=latest""
    virtualbox-iso: "==> Got chef download URL: https://packages.chef.io/files/stable/chef/15.6.10/windows/2019/chef-client-15.6.10-1-x64.msi"
    virtualbox-iso: ==> Creating "C:\Users\vagrant\AppData\Local\Temp\chef"
    virtualbox-iso: ==> Downloading "https://packages.chef.io/files/stable/chef/15.6.10/windows/2019/chef-client-15.6.10-1-x64.msi" to "C:\Users\vagrant\AppData\Local\Temp\chef\chef-client-15.6.10-1-x64.msi"
  ```