### PR TITLE
This PR adds support for passing oob options to the cmtool.bat script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ PACKER_VARS := -var 'cm=$(CM)' -var 'version=$(BOX_VERSION)' -var 'update=$(UPDA
 ifdef HW_VERSION
 	PACKER_VARS += -var 'hw_version=$(HW_VERSION)'
 endif
+ifdef CM_OPTIONS
+	PACKER_VARS += -var 'cm_options=$(CM_OPTIONS)'
+endif
 ifdef CM_VERSION
 	PACKER_VARS += -var 'cm_version=$(CM_VERSION)'
 endif

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -172,6 +172,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -172,6 +172,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -168,6 +168,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -148,6 +148,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -88,6 +88,7 @@ goto chef
 ::::::::::::
 :chef
 ::::::::::::
+if not defined CHEF_OPTIONS set CHEF_OPTIONS=%CM_OPTIONS%
 
 for %%i in ("%CHEF_URL%") do set CHEF_MSI=%%~nxi
 set CHEF_DIR=%TEMP%\chef
@@ -116,6 +117,7 @@ goto exit0
 ::::::::::::
 :puppet
 ::::::::::::
+if not defined PUPPET_OPTIONS set PUPPET_OPTIONS=%CM_OPTIONS%
 
 :: if "%CM_VERSION%" == "latest" set CM_VERSION=3.8.7
 
@@ -157,6 +159,7 @@ goto exit0
 ::::::::::::
 :salt
 ::::::::::::
+if not defined SALT_OPTIONS set SALT_OPTIONS=%CM_OPTIONS%
 
 if "%CM_VERSION%" == "latest" set CM_VERSION=2015.8.8-2
 

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -44,8 +44,15 @@ if "%CM%" == "chef" (
 
 :: Deterine the other desired parameters here
 if not defined OMNITRUCK_PLATFORM set OMNITRUCK_PLATFORM=windows
-if not defined OMNITRUCK_MACHINE_ARCH set OMNITRUCK_MACHINE_ARCH=%PROCESSOR_ARCHITECTURE%
 if not defined OMNITRUCK_VERSION set OMNITRUCK_VERSION=%CM_VERSION%
+
+if not defined OMNITRUCK_MACHINE_ARCH (
+  if "%PROCESSOR_ARCHITECTURE%" == "x86" (
+    set OMNITRUCK_MACHINE_ARCH=x86
+  ) else (
+    set OMNITRUCK_MACHINE_ARCH=x64
+  )
+)
 
 :: We exclude the platform version as the Omnitruck API doesn't seem to use this
 :: set OMNITRUCK_PLATFORM_VERSION=

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -157,6 +157,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -151,6 +151,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -154,6 +154,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -152,6 +152,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -155,6 +155,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -156,6 +156,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -160,6 +160,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -146,6 +146,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -142,6 +142,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -143,6 +143,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -147,6 +147,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -136,6 +136,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -140,6 +140,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -136,6 +136,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -139,6 +139,7 @@
     {
       "environment_vars": [
         "CM={{user `cm`}}",
+        "CM_OPTIONS={{user `cm_options`}}",
         "CM_VERSION={{user `cm_version`}}",
         "UPDATE={{user `update`}}"
       ],


### PR DESCRIPTION
One of the older PRs that was submitted (#182) added a user variable `CM_OPTIONS` that allowed one to pass options to the salt-bootstrap script. A recent PR adds a `CHEF_LICENSE` option in order to pass options into the script/cmtool.bat script in order to allow the user to constrain the licensing for chef.

It is likely in the future that there might be more configurable options that could be exposed in order to customize the user's chosen cmtool. So in order to support passing an oob option to the configuration of a cmtool, this PR aims to consolidate all of those needs into a single user variable, `CM_OPTIONS`. This should hopefully reduce the template complexity of adding an explicit user variable for every possible cmtool installation feature in the future.

It is intended that the semantics of this option is specific to the cmtool as not all cmtools need arbitrarily flexible parameters.