### PR TITLE
Added support for falling back to the saltrepository method int script/cmtool.bat for older versions of windows.

### DIFF
--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -186,6 +186,7 @@ pushd "%SALT_DIR%"
 
 :: If we're on a platform where salt-bootstrap is buggy, then fall back to just
 :: using the regular salt-repository method.
+if "%PlatformVersionMajor%" == "5" goto saltrepository
 if "%PlatformVersionMajor%" == "6" if "%PlatformVersionMinor%" == "0" goto saltrepository
 if "%PlatformVersionMajor%" == "6" if "%PlatformVersionMinor%" == "1" goto saltrepository
 


### PR DESCRIPTION
The previous PR #201 which adds support for using salt-bootstrap to install saltstack forgot to include support for windows server 2008 and some of the others. This PR fixes that by extending the platform veresion check to those versions. The major version for those platforms is 5.

This closes issue #204.