### PR TITLE
Re-enabled the user-interface for updates, whilst still keeping them completely disabled by default

### DIFF
--- a/floppy/disablewinupdate.bat
+++ b/floppy/disablewinupdate.bat
@@ -13,7 +13,7 @@ SC config wuauserv start= disabled
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v AUOptions /t REG_DWORD /d 2 /f
 
 :: turn the whole thing off
-reg add "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" /v DisableWindowsUpdateAccess /t REG_DWORD /d 1 /f
+reg add "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" /v DisableWindowsUpdateAccess /t REG_DWORD /d 0 /f
 reg add "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU" /v NoAutoUpdate /t REG_DWORD /d 1 /f
 
 :: disable the update prompt scheduled tasks


### PR DESCRIPTION
Currently the `floppy/disablewinupdate.bat` script performs a number of actions to completely disable windows updates. One of these actions is to disable the windows updates user interface. This action doesn't interfere with the updates being disabled, but prevents the user from interacting with Windows updates at all. Actually, windows updates will still work with the interface disabled so this doesn't seem to be of the utmost necessity.

Disabling the Windows Updates interface actually has the side-effect of preventing some KBs from being installed, or features from being enabled/disabled. This can interfere with provisioning as you'll have to specifically fix this w/ group policy or registry and then you'll need to enable/restart wuauserv to have access to them again.

This PR leaves the option there, but sets it to 0. This way that despite updates being disabled, the user can still choose to configure them if they want to. This will also allow the user to add/remove windows features without interference.

This is in response to my issue #209.