### PR TITLE
Updated the chef installer in script/cmtool.bat to use "latest" to constrain to the latest non-licensed (free) version, and "licensed" to use the latest licensed (non-free) version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,20 @@ You can also specify a variable `CM_VERSION` for all configuration management
 tools to override the default of `latest`. The value of `CM_VERSION` should
 have the form `x.y` or `x.y.z`, such as `CM_VERSION := 11.12.4`
 
+When changing the value of the `CM` variable to one of the chef-based
+configuration management tools, it is relevant to note that recent versions of
+chef require a license in order to use. Due to this, specifying the default
+version of "latest" for the `CM_VERSION` field will result in using the most
+recent "free" version that doesn't require a license. If the user wishes to use
+the most recent version that DOES requires licensing, however, the user will
+need to explicitly specify "licensed" for `CM_VERSION`. Specifying "licensed"
+for `CM_VERSION` will then result in using the most recently available licensed
+version. More information on how to accept the chef-client license via
+configuration after building a template can be found at
+[Accepting the Chef License](https://docs.chef.io/chef_license_accept.html).
+
 It is also possible to specify a `HW_VERSION` if a specific hardware
-version is to be used for build. This is commonly used to provide
+version is to be used for a build. This is commonly used to provide
 compatibility with newer versions of VMware Workstation. For example,
 you may indicate version 14 of Workstation: `HW_VERSION := 14`.
 

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -71,6 +71,10 @@ if "%CM_VERSION%" == "latest" (
 ) else if "%CM_VERSION%" == "licensed" (
     echo ==^> User has chosen the most recent licensed version of %OMNITRUCK_PRODUCT%
     set OMNITRUCK_VERSION=latest
+
+:: ...or an explicit version if they explicitly set the environment variable in their own patch
+) else if defined OMNITRUCK_VERSION (
+    echo ==^> User has explicitly chosen the version %OMNITRUCK_VERSION% for %OMNITRUCK_PRODUCT%
 )
 
 :: Deterine the other desired parameters here

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -50,13 +50,27 @@ if not defined OMNITRUCK_CHANNEL set OMNITRUCK_CHANNEL=stable
 :: Figure out the Omnitruck product
 if "%CM%" == "chef" (
   set "OMNITRUCK_PRODUCT=chef"
+  set "OMNITRUCK_FREE_VERSION=14.14.29"
 ) else if "%CM%" == "chefdk" (
   set "OMNITRUCK_PRODUCT=chefdk"
+  set "OMNITRUCK_FREE_VERSION=3.12.10"
 ) else if "%CM%" == "chef-workstation" (
   set "OMNITRUCK_PRODUCT=chef-workstation"
+  set "OMNITRUCK_FREE_VERSION=0.3.2"
 ) else (
   echo Unknown Chef Product: %CM%
   goto exit1
+)
+
+:: Check if the user has chosen the most recent free version..
+if "%CM_VERSION%" == "latest" (
+    echo ==^> User has chosen the most recent free version of %OMNITRUCK_PRODUCT%
+    set OMNITRUCK_VERSION=%OMNITRUCK_FREE_VERSION%
+
+:: ...or the most recent licensed version.
+) else if "%CM_VERSION%" == "licensed" (
+    echo ==^> User has chosen the most recent licensed version of %OMNITRUCK_PRODUCT%
+    set OMNITRUCK_VERSION=latest
 )
 
 :: Deterine the other desired parameters here

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -101,7 +101,7 @@ echo ==^> Getting %OMNITRUCK_PRODUCT% %OMNITRUCK_VERSION% %OMNITRUCK_MACHINE_ARC
 set url="https://omnitruck.chef.io/%OMNITRUCK_CHANNEL%/%OMNITRUCK_PRODUCT%/metadata?p=%OMNITRUCK_PLATFORM%&m=%OMNITRUCK_MACHINE_ARCH%&v=%OMNITRUCK_VERSION%"
 set filename="%TEMP%\omnitruck.txt"
 
-echo "==^> Using Chef Omnitruck API URL: !url!"
+echo ==^> Using Chef Omnitruck API URL: !url!
 powershell -command "(New-Object System.Net.WebClient).DownloadFile('!url!', '!filename!')"
 
 if not exist "%TEMP%\omnitruck.txt" (
@@ -117,7 +117,7 @@ if not defined CHEF_URL (
   echo Could not determine the %OMNITRUCK_PRODUCT% %OMNITRUCK_VERSION% download url...
   goto exit1
 )
-echo "==^> Got %OMNITRUCK_PRODUCT% download URL: !CHEF_URL!"
+echo ==^> Got %OMNITRUCK_PRODUCT% download URL: !CHEF_URL!
 
 goto chef
 

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -62,18 +62,19 @@ if "%CM%" == "chef" (
   goto exit1
 )
 
-:: Check if the user has chosen the most recent free version..
+:: Check the CM_VERSION that the user specified..
 if "%CM_VERSION%" == "latest" (
+    :: ...and let them know if they chose the most recent free version.
     echo ==^> User has chosen the most recent free version of %OMNITRUCK_PRODUCT%
     set OMNITRUCK_VERSION=%OMNITRUCK_FREE_VERSION%
 
-:: ...or the most recent licensed version.
 ) else if "%CM_VERSION%" == "licensed" (
+    :: ...or the most recent licensed version.
     echo ==^> User has chosen the most recent licensed version of %OMNITRUCK_PRODUCT%
     set OMNITRUCK_VERSION=latest
 
-:: ...or an explicit version if they explicitly set the environment variable in their own patch
 ) else if defined OMNITRUCK_VERSION (
+    :: ...or their own version if they explicitly set an environment variable
     echo ==^> User has explicitly chosen the version %OMNITRUCK_VERSION% for %OMNITRUCK_PRODUCT%
 )
 


### PR DESCRIPTION
By default here, setting `CM_VERSION` to `latest` will result in querying omnitruck for the most recent free version of chef. Setting `CM_VERSION` to `licensed` will result in querying omnitruck for the most recent licensed version of chef.

Do not merge this as-is as this will need to be documented, tested, and likely cleaned up a little.