### PR TITLE
[WIP] Quick example of using "licensed" to use the most recent licensed version of chef in script/cmtool.bat, yet by default use the most recent free version.

### DIFF
--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -50,16 +50,36 @@ if not defined OMNITRUCK_CHANNEL set OMNITRUCK_CHANNEL=stable
 :: Figure out the Omnitruck product
 if "%CM%" == "chef" (
   set "OMNITRUCK_PRODUCT=chef"
+  set "OMNITRUCK_FREE_VERSION=14.14.29"
 ) else if "%CM%" == "chefdk" (
   set "OMNITRUCK_PRODUCT=chefdk"
+  set "OMNITRUCK_FREE_VERSION=3.12.10"
 ) else if "%CM%" == "chef-workstation" (
   set "OMNITRUCK_PRODUCT=chef-workstation"
+  set "OMNITRUCK_FREE_VERSION=0.3.2"
 ) else (
   echo Unknown Chef Product: %CM%
   goto exit1
 )
 
-:: Deterine the other desired parameters here
+:: Check our options to see if the user specified to use a licensed version or not
+set licensed=false
+for /f "delims=," %%a in ("%CM_OPTIONS%") do (
+  if "%%a" == "licensed" set licensed=true
+)
+
+:: Check if the user has chosen the most recent free version..
+if "%CM_VERSION%" == "latest" (
+  if "%licensed%" == "false" (
+    echo ==^> User has chosen the most recent free version of %OMNITRUCK_PRODUCT%
+    set OMNITRUCK_VERSION=%OMNITRUCK_FREE_VERSION%
+  ) else (
+    echo ==^> User has chosen the most recent licensed version of %OMNITRUCK_PRODUCT%
+    set OMNITRUCK_VERSION=latest
+  )
+)
+
+:: Determine the other desired parameters here
 if not defined OMNITRUCK_PLATFORM set OMNITRUCK_PLATFORM=windows
 if not defined OMNITRUCK_VERSION set OMNITRUCK_VERSION=%CM_VERSION%
 


### PR DESCRIPTION
By adding "licensed" to the comma-separated `CM_OPTIONS` field, this will result in omnitruck being queried for the most recent licensed version of chef. If "licensed" isn't defined, then by default omnitruck will be queried for the most recent free version of chef.

Do not merge this as-is as this will need to be documented, tested, and likely cleaned up a little.