### PR TITLE
Fixed the vm_name used by the win2012r2-standardcore-ssh.json template

### DIFF
--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standardcore",
+      "vm_name": "win2012r2-standardcore-ssh",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standardcore"
+      "vm_name": "win2012r2-standardcore-ssh"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -109,7 +109,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standardcore"
+      "vm_name": "win2012r2-standardcore-ssh"
     },
     {
       "cpus": "{{ user `cpus` }}",


### PR DESCRIPTION
The `vm_name` field used in the `vmware-iso`, `virtualbox-iso`, and `parallels-iso` builders of the `win2012r2-standardcore-ssh.json` template is actually missing its `-ssh` suffix. This results in a duplicate name of the emitted template and can affect building if the win2012r2-standardcore templates are being built at the same time.

This PR simply updates the `vm_name` field in all the builders so that they contain the `-ssh` suffix similar to the other `-ssh.json` templates.

This closes issue #214.