### PR TITLE
Update all the templates so that the vm_name and suffix are defined in user variables

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -205,11 +205,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x64-enterprise-cygwin",
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -163,7 +163,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-cygwin.tpl"
     }
@@ -197,19 +197,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x64-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x64-enterprise-cygwin",
-    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -197,8 +197,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win10x64-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win10x64-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -32,7 +32,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x64-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -87,7 +87,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -122,7 +122,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -156,14 +156,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-cygwin.tpl"
     }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-ssh.tpl"
     }
@@ -193,19 +193,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x64-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x64-enterprise-ssh",
-    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -31,7 +31,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x64-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -85,7 +85,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -119,7 +119,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -152,14 +152,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise-ssh.tpl"
     }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -201,11 +201,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x64-enterprise-ssh",
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -193,8 +193,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win10x64-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win10x64-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x64-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x64-enterprise",
-    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x64-enterprise",
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -28,7 +28,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -82,7 +82,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -116,7 +116,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -149,7 +149,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x64-enterprise.tpl"
     }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -32,7 +32,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x86-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -87,7 +87,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -122,7 +122,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -156,14 +156,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-cygwin.tpl"
     }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -163,7 +163,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-cygwin.tpl"
     }
@@ -197,19 +197,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x86-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x86-enterprise-cygwin",
-    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -197,8 +197,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win10x86-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win10x86-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -205,11 +205,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x86-enterprise-cygwin",
     "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-ssh.tpl"
     }
@@ -193,19 +193,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x86-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x86-enterprise-ssh",
-    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+    "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -201,11 +201,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x86-enterprise-ssh",
     "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -31,7 +31,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x86-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -85,7 +85,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -119,7 +119,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -152,14 +152,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise-ssh.tpl"
     }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -193,8 +193,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win10x86-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win10x86-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win10x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win10x86-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win10x86-enterprise",
-    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
+    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win10x86-enterprise",
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x86FRE_en-us.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -28,7 +28,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win10x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -82,7 +82,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win10x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -116,7 +116,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win10x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -149,7 +149,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win10x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -159,7 +159,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win10x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win10x86-enterprise.tpl"
     }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-datacenter-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-cygwin.tpl"
     }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-datacenter-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-datacenter-cygwin",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2008r2-datacenter-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win2008r2-datacenter",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-datacenter-cygwin",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-datacenter-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-ssh.tpl"
     }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2008r2-datacenter-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win2008r2-datacenter",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-datacenter-ssh",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter-ssh.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-datacenter-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-datacenter-ssh",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-datacenter",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-datacenter",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -25,7 +25,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -67,7 +67,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -98,7 +98,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -128,7 +128,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-datacenter.tpl"
     }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-datacenter",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-standard-cygwin",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-cygwin.tpl"
     }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2008r2-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win2008r2-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-standard-cygwin",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-standard-ssh",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -95,7 +95,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -123,14 +123,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-ssh.tpl"
     }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -164,8 +164,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2008r2-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win2008r2-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard-ssh.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-standard-ssh",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -65,7 +65,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -95,7 +95,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -124,7 +124,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard.tpl"
     }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -168,11 +168,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2008r2-standard",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2008r2-standard.tpl"
     }
@@ -160,19 +160,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2008r2-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2008r2-standard",
-    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-cygwin.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-datacenter-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-datacenter-cygwin",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -185,8 +185,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2012r2-datacenter-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win2012r2-datacenter",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-datacenter-cygwin",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-datacenter-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -115,7 +115,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -144,14 +144,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-cygwin.tpl"
     }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2012r2-datacenter-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win2012r2-datacenter",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-datacenter-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-ssh.tpl"
     }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter-ssh.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-datacenter-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-datacenter-ssh",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-datacenter-ssh",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -74,7 +74,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -112,7 +112,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -141,7 +141,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter.tpl"
     }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-datacenter",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-datacenter.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-datacenter",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-datacenter",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-standard-cygwin",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-cygwin.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-standard-cygwin",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -115,7 +115,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -144,14 +144,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-cygwin.tpl"
     }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -185,8 +185,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2012r2-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win2012r2-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-ssh.tpl"
     }

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard-ssh.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-standard-ssh",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2012r2-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win2012r2-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-standard-ssh",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2012r2-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2012r2-standard",
-    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "hw_version": "7",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2012r2-standard",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -74,7 +74,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -112,7 +112,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -141,7 +141,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2012r2-standard.tpl"
     }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2016-standard-cygwin",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2016-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -115,7 +115,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -144,14 +144,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-cygwin.tpl"
     }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -185,8 +185,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2016-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win2016-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-cygwin.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2016-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2016-standard-cygwin",
-    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "hw_version": "7",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-ssh.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2016-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2016-standard-ssh",
-    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "hw_version": "7",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win2016-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win2016-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2016-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard-ssh.tpl"
     }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2016-standard-ssh",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win2016-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win2016-standard",
-    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "hw_version": "7",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -74,7 +74,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -112,7 +112,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -141,7 +141,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win2016-standard.tpl"
     }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win2016-standard",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -29,7 +29,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x64-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -72,7 +72,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -135,14 +135,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
     }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -176,8 +176,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win7x64-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win7x64-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-cygwin.tpl"
     }
@@ -176,19 +176,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "3072",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x64-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "3072",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x64-enterprise-cygwin",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -184,11 +184,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x64-enterprise-cygwin",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -29,7 +29,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x64-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -72,7 +72,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -135,14 +135,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-ssh.tpl"
     }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise-ssh.tpl"
     }
@@ -176,19 +176,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "3072",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x64-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "3072",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x64-enterprise-ssh",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -184,11 +184,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x64-enterprise-ssh",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -176,8 +176,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win7x64-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win7x64-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x64-enterprise",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "3072",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x64-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "3072",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x64-enterprise",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -26,7 +26,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -69,7 +69,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -101,7 +101,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "20000s",
       "winrm_username": "vagrant"
@@ -132,7 +132,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x64-enterprise.tpl"
     }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-cygwin.tpl"
     }
@@ -176,19 +176,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x86-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x86-enterprise-cygwin",
-    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -176,8 +176,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win7x86-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win7x86-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -29,7 +29,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x86-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -72,7 +72,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -135,14 +135,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-cygwin.tpl"
     }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -184,11 +184,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x86-enterprise-cygwin",
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -171,8 +171,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win7x86-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win7x86-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x86-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -130,14 +130,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-ssh.tpl"
     }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise-ssh.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x86-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x86-enterprise-ssh",
-    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x86-enterprise-ssh",
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win7x86-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win7x86-enterprise",
-    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -25,7 +25,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -67,7 +67,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "eval-win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -98,7 +98,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -128,7 +128,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win7x86-enterprise.tpl"
     }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win7x86-enterprise",
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x64-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -107,7 +107,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-cygwin.tpl"
     }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x64-enterprise-cygwin",
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win81x64-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win81x64-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-cygwin.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x64-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x64-enterprise-cygwin",
-    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x64-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -107,7 +107,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-ssh.tpl"
     }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x64-enterprise-ssh",
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win81x64-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win81x64-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise-ssh.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x64-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x64-enterprise-ssh",
-    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise.tpl"
     }
@@ -173,19 +173,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x64-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x64-enterprise",
-    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
+    "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -181,11 +181,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x64-enterprise",
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X64FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -25,7 +25,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -76,7 +76,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -107,7 +107,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -137,7 +137,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x64-enterprise.tpl"
     }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x86-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -107,7 +107,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-cygwin.tpl"
     }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-cygwin.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x86-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x86-enterprise-cygwin",
-    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win81x86-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "eval-win81x86-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x86-enterprise-cygwin",
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -139,7 +139,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-ssh.tpl"
     }
@@ -173,19 +173,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x86-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x86-enterprise-ssh",
-    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x86-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -132,14 +132,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise-ssh.tpl"
     }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -181,11 +181,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x86-enterprise-ssh",
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -173,8 +173,8 @@
     }
   ],
   "variables": {
-    "vm_name": "eval-win81x86-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "eval-win81x86-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "eval-win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -74,7 +74,7 @@
           "1"
         ]
       ],
-      "vm_name": "eval-win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -104,7 +104,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "eval-win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "eval-win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise.tpl"
     }

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -177,11 +177,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "eval-win81x86-enterprise",
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/eval-win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/eval-win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-eval-win81x86-enterprise.tpl"
     }
@@ -169,19 +169,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "eval-win81x86-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "eval-win81x86-enterprise",
-    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/B/9/9/B999286E-0A47-406D-8B3D-5B5AD7373A4A/9600.17050.WINBLUE_REFRESH.140317-1640_X86FRE_ENTERPRISE_EVAL_EN-US-IR3_CENA_X86FREE_EN-US_DV9.ISO",
+    "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-datacenter-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-datacenter",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-datacenter-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl"
     }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-datacenter-cygwin",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-datacenter-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-datacenter-cygwin",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-datacenter-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -95,7 +95,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -123,14 +123,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-ssh.tpl"
     }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter-ssh.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-datacenter-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-datacenter-ssh",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -164,8 +164,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-datacenter-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-datacenter",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-datacenter-ssh",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-datacenter",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter.tpl"
     }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-datacenter.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-datacenter",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-datacenter",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-enterprise-cygwin",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl"
     }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-enterprise-cygwin",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -95,7 +95,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -123,14 +123,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-ssh.tpl"
     }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -164,8 +164,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise-ssh.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-enterprise-ssh",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-enterprise-ssh",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-enterprise",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-enterprise.tpl"
     }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-enterprise",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-standard-cygwin",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-cygwin.tpl"
     }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-standard-cygwin",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-standard-ssh",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -164,8 +164,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-ssh.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-standard-ssh",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -95,7 +95,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -123,14 +123,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard-ssh.tpl"
     }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard.tpl"
     }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-standard.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-standard",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-standard",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-web-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-web-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-web-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-web-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-cygwin.tpl"
     }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-web-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-cygwin.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-web-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-web-cygwin",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-web-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-web",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-web-cygwin",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-web-ssh",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-web-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-web-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -95,7 +95,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-web-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -123,14 +123,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-web-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-ssh.tpl"
     }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-web-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web-ssh.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-web-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-web-ssh",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -164,8 +164,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2008r2-web-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2008r2-web",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2008r2-web",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2008r2-web",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2008r2-web",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2008r2-web",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web.tpl"
     }

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2008r2-web",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2008r2-web-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2008r2-web-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2008r2-web.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2008r2-web",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2008r2-web",
-    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
+    "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -180,8 +180,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012-datacenter-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2012-datacenter",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -188,11 +188,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-datacenter-cygwin",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-datacenter-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -109,7 +109,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -139,14 +139,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-cygwin.tpl"
     }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-cygwin.tpl"
     }
@@ -180,19 +180,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-datacenter-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-datacenter-cygwin",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-datacenter-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -106,7 +106,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -135,14 +135,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-ssh.tpl"
     }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -184,11 +184,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-datacenter-ssh",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -176,8 +176,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012-datacenter-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2012-datacenter",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter-ssh.tpl"
     }
@@ -176,19 +176,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-datacenter-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-datacenter-ssh",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-datacenter",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -25,7 +25,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -105,7 +105,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2012-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -135,7 +135,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2012-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter.tpl"
     }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-datacenter.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-datacenter",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-datacenter",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -148,7 +148,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-cygwin.tpl"
     }
@@ -182,19 +182,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-standard-cygwin",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -190,11 +190,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-standard-cygwin",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -182,8 +182,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2012-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -72,7 +72,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -111,7 +111,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -141,14 +141,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-cygwin.tpl"
     }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -176,8 +176,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2012-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -142,7 +142,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-ssh.tpl"
     }
@@ -176,19 +176,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-standard-ssh",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -106,7 +106,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -135,14 +135,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard-ssh.tpl"
     }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -184,11 +184,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-standard-ssh",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -25,7 +25,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -66,7 +66,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win2012-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -105,7 +105,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2012-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -135,7 +135,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2012-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard.tpl"
     }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012-standard",
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -145,7 +145,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012-standard.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012-standard",
-    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-datacenter-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-datacenter",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-datacenter-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-datacenter-cygwin",
-    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
+    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-datacenter-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-datacenter-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-cygwin.tpl"
     }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-datacenter-cygwin",
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-datacenter-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -109,7 +109,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-datacenter-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-ssh.tpl"
     }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-datacenter-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-datacenter",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-datacenter-ssh",
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter-ssh.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-datacenter-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-datacenter-ssh",
-    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
+    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -180,11 +180,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-datacenter",
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -71,7 +71,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -108,7 +108,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -136,7 +136,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-datacenter",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter.tpl"
     }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-datacenter-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-datacenter.tpl"
     }
@@ -172,19 +172,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-datacenter",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-datacenter",
-    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
+    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -180,8 +180,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-cygwin.tpl"
     }
@@ -180,19 +180,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standard-cygwin",
-    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
+    "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -188,11 +188,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standard-cygwin",
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_4065220.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -139,14 +139,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-cygwin.tpl"
     }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standard-ssh",
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-ssh.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standard-ssh",
-    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -109,7 +109,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard-ssh.tpl"
     }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard.tpl"
     }
@@ -172,19 +172,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standard",
-    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -180,11 +180,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standard",
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -71,7 +71,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -108,7 +108,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -136,7 +136,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standard.tpl"
     }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-standardcore-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-standardcore",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standardcore-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore-cygwin.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standardcore-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standardcore-cygwin",
-    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standardcore-cygwin",
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standardcore-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standardcore-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standardcore-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standardcore-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore-cygwin.tpl"
     }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -143,7 +143,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standardcore-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standardcore-ssh",
-    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -177,8 +177,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2012r2-standardcore-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2012r2-standardcore",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standardcore-ssh",
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standardcore-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standardcore-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -109,7 +109,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standardcore-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -136,14 +136,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standardcore-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2012r2-standardcore",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -71,7 +71,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2012r2-standardcore",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -108,7 +108,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2012r2-standardcore",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -136,7 +136,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2012r2-standardcore",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -146,7 +146,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2012r2-standardcore-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2012r2-standardcore.tpl"
     }
@@ -172,19 +172,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2012r2-standardcore",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2012r2-standardcore",
-    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -180,11 +180,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2012r2-standardcore",
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "iso_url": "iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2016-standard-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -77,7 +77,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -115,7 +115,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -144,14 +144,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2016-standard-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-cygwin.tpl"
     }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-cygwin.tpl"
     }
@@ -185,19 +185,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2016-standard-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2016-standard-cygwin",
-    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
+    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -185,8 +185,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2016-standard-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win2016-standard",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -193,11 +193,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2016-standard-cygwin",
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -189,11 +189,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2016-standard-ssh",
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2016-standard-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -140,14 +140,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win2016-standard-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-ssh.tpl"
     }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -147,7 +147,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard-ssh.tpl"
     }
@@ -181,19 +181,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2016-standard-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2016-standard-ssh",
-    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
+    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -181,8 +181,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win2016-standard-ssh",
-    "vm_suffix": "",
+    "vm_name": "win2016-standard",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -185,11 +185,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win2016-standard",
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard.tpl"
     }
@@ -177,19 +177,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win2016-standard",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win2016-standard",
-    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_server_2016_x64_dvd_9718492.iso",
+    "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -74,7 +74,7 @@
           "1"
         ]
       ],
-      "vm_name": "win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -112,7 +112,7 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -141,7 +141,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win2016-standard",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -151,7 +151,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": true,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win2016-standard-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win2016-standard.tpl"
     }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-enterprise-cygwin",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -171,8 +171,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x64-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win7x64-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-enterprise-cygwin",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -130,14 +130,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-cygwin.tpl"
     }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -175,11 +175,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-enterprise-ssh",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-ssh.tpl"
     }
@@ -167,19 +167,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-enterprise-ssh",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -126,14 +126,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise-ssh.tpl"
     }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -167,8 +167,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x64-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "win7x64-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise.tpl"
     }

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-enterprise",
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-enterprise.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-enterprise",
-    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "hw_version": "7",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+    "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-pro-cygwin",
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-cygwin.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-pro-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-pro-cygwin",
-    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
+    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-pro-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -130,14 +130,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-cygwin.tpl"
     }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -171,8 +171,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x64-pro-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win7x64-pro",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -175,11 +175,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-pro-ssh",
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-pro-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -126,14 +126,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-ssh.tpl"
     }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -167,8 +167,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x64-pro-ssh",
-    "vm_suffix": "",
+    "vm_name": "win7x64-pro",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro-ssh.tpl"
     }
@@ -167,19 +167,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-pro-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-pro-ssh",
-    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
+    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win7x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win7x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro.tpl"
     }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x64-pro",
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x64-pro.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x64-pro",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x64-pro",
-    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x64_dvd_u_677791.iso",
+    "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-enterprise-cygwin",
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -171,8 +171,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x86-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win7x86-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-enterprise-cygwin",
-    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
+    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -130,14 +130,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-cygwin.tpl"
     }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -167,8 +167,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x86-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "win7x86-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-ssh.tpl"
     }
@@ -167,19 +167,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-enterprise-ssh",
-    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
+    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -126,14 +126,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise-ssh.tpl"
     }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -175,11 +175,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-enterprise-ssh",
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise.tpl"
     }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-enterprise.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-enterprise",
-    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
+    "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-enterprise",
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "iso_url": "iso/en_windows_7_enterprise_with_sp1_x86_dvd_u_677710.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -28,7 +28,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-pro-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -70,7 +70,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -130,14 +130,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-cygwin.tpl"
     }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -179,11 +179,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-pro-cygwin",
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -137,7 +137,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-cygwin.tpl"
     }
@@ -171,19 +171,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-pro-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-pro-cygwin",
-    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
+    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -171,8 +171,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x86-pro-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win7x86-pro",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-ssh.tpl"
     }
@@ -167,19 +167,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-pro-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-pro-ssh",
-    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
+    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -167,8 +167,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win7x86-pro-ssh",
-    "vm_suffix": "",
+    "vm_name": "win7x86-pro",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -27,7 +27,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-pro-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -68,7 +68,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -98,7 +98,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win7x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -126,14 +126,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro-ssh.tpl"
     }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -175,11 +175,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-pro-ssh",
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win7x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro.tpl"
     }
@@ -159,19 +159,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win7x86-pro",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win7x86-pro",
-    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
+    "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -167,11 +167,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win7x86-pro",
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "iso_url": "iso/en_windows_7_professional_with_sp1_vl_build_x86_dvd_u_677896.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -24,7 +24,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win7x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -64,7 +64,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win7x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -94,7 +94,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win7x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -123,7 +123,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win7x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -133,7 +133,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win7x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win7x86-pro.tpl"
     }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -131,14 +131,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl"
     }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -172,8 +172,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x64-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win81x64-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -180,11 +180,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-enterprise-cygwin",
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-cygwin.tpl"
     }
@@ -172,19 +172,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-enterprise-cygwin",
-    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
+    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-enterprise-ssh",
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-ssh.tpl"
     }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise-ssh.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-enterprise-ssh",
-    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
+    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x64-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "win81x64-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -71,7 +71,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -100,7 +100,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -128,7 +128,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise.tpl"
     }

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-enterprise",
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-enterprise.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-enterprise",
-    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x64_dvd_4065178.iso",
+    "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-pro-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -75,7 +75,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -104,7 +104,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -131,14 +131,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-cygwin.tpl"
     }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-cygwin.tpl"
     }
@@ -172,19 +172,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-pro-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-pro-cygwin",
-    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
+    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -180,11 +180,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-pro-cygwin",
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -172,8 +172,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x64-pro-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win81x64-pro",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-pro-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -73,7 +73,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -101,7 +101,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -127,14 +127,14 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-ssh.tpl"
     }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -176,11 +176,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-pro-ssh",
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -134,7 +134,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro-ssh.tpl"
     }
@@ -168,19 +168,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-pro-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-pro-ssh",
-    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
+    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -168,8 +168,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x64-pro-ssh",
-    "vm_suffix": "",
+    "vm_name": "win81x64-pro",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -172,11 +172,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x64-pro",
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro.tpl"
     }
@@ -164,19 +164,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x64-pro",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x64-pro",
-    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x64_dvd_4065194.iso",
+    "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -71,7 +71,7 @@
           "1"
         ]
       ],
-      "vm_name": "win81x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -100,7 +100,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win81x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -128,7 +128,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win81x64-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -138,7 +138,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x64-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x64-pro.tpl"
     }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -173,11 +173,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-enterprise-cygwin",
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -165,8 +165,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x86-enterprise-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win81x86-enterprise",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-enterprise-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -67,7 +67,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -96,7 +96,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -124,14 +124,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-enterprise-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl"
     }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -131,7 +131,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-cygwin.tpl"
     }
@@ -165,19 +165,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-enterprise-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-enterprise-cygwin",
-    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
+    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -127,7 +127,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-ssh.tpl"
     }
@@ -161,19 +161,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-enterprise-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-enterprise-ssh",
-    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
+    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -161,8 +161,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x86-enterprise-ssh",
-    "vm_suffix": "",
+    "vm_name": "win81x86-enterprise",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-enterprise-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -65,7 +65,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -93,7 +93,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -120,14 +120,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-enterprise-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise-ssh.tpl"
     }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -169,11 +169,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-enterprise-ssh",
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -164,11 +164,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-enterprise",
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -63,7 +63,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -92,7 +92,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -120,7 +120,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-enterprise",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise.tpl"
     }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-enterprise-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-enterprise.tpl"
     }
@@ -156,19 +156,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-enterprise",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-enterprise",
-    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_enterprise_with_update_x86_dvd_4065185.iso",
+    "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -131,7 +131,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-cygwin.tpl"
     }
@@ -165,19 +165,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-pro-cygwin",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-pro-cygwin",
-    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
+    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -173,11 +173,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-pro-cygwin",
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -26,7 +26,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-pro-cygwin",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -67,7 +67,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -96,7 +96,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -124,14 +124,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-pro-cygwin"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-cygwin-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-cygwin.tpl"
     }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -165,8 +165,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x86-pro-cygwin",
-    "vm_suffix": "",
+    "vm_name": "win81x86-pro",
+    "vm_suffix": "-cygwin",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -127,7 +127,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-ssh.tpl"
     }
@@ -161,19 +161,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-pro-ssh",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-pro-ssh",
-    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
+    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -169,11 +169,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-pro-ssh",
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -161,8 +161,8 @@
     }
   ],
   "variables": {
-    "vm_name": "win81x86-pro-ssh",
-    "vm_suffix": "",
+    "vm_name": "win81x86-pro",
+    "vm_suffix": "-ssh",
     "cm": "chef",
     "cm_version": "",
     "cpus": "2",

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -25,7 +25,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-pro-ssh",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -65,7 +65,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "disk_size": "{{user `disk_size`}}",
@@ -93,7 +93,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "win81x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     },
     {
       "cpus": "{{ user `cpus` }}",
@@ -120,14 +120,14 @@
       "ssh_username": "vagrant",
       "ssh_timeout": "10000s",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-pro-ssh"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-ssh-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro-ssh.tpl"
     }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_prefix` }}{{.Provider}}/win81x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro.tpl"
     }
@@ -156,19 +156,20 @@
     }
   ],
   "variables": {
-    "cpus": "2",
-    "memory": "2048",
-    "guest_additions_url": "",
+    "vm_name": "win81x86-pro",
+    "vm_suffix": "",
     "cm": "chef",
     "cm_version": "",
-    "hw_version": "7",
+    "cpus": "2",
+    "memory": "2048",
     "disk_size": "40960",
-    "headless": "false",
-    "box_prefix": "box/",
-    "vm_name": "win81x86-pro",
-    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "hw_version": "7",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
+    "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
+    "guest_additions_url": "",
+    "box_directory": "box/",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "headless": "false",
     "update": "true",
     "version": "0.1.0"
   }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -164,11 +164,12 @@
     "hw_version": "7",
     "disk_size": "40960",
     "headless": "false",
+    "box_prefix": "box/",
+    "vm_name": "win81x86-pro",
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "iso_url": "iso/en_windows_8.1_professional_vl_with_update_x86_dvd_4065201.iso",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "update": "true",
-    "version": "0.1.0",
-    "box_prefix": "box/"
+    "version": "0.1.0"
   }
 }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -23,7 +23,7 @@
       "shutdown_command": "{{ user `shutdown_command`}}",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
-      "vm_name": "win81x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "version": "{{ user `hw_version` }}",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
@@ -63,7 +63,7 @@
       "type": "virtualbox-iso",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
-      "vm_name": "win81x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -92,7 +92,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "parallels-iso",
-      "vm_name": "win81x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -120,7 +120,7 @@
       "memory": "{{ user `memory` }}",
       "shutdown_command": "{{ user `shutdown_command`}}",
       "type": "hyperv-iso",
-      "vm_name": "win81x86-pro",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "10000s",
       "winrm_username": "vagrant"
@@ -130,7 +130,7 @@
     {
       "compression_level": 1,
       "keep_input_artifact": false,
-      "output": "{{ user `box_directory` }}{{.Provider}}/win81x86-pro-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
+      "output": "{{user `box_directory`}}{{.Provider}}/{{user `vm_name`}}{{user `vm_suffix`}}-{{user `cm`}}{{user `cm_version`}}-{{user `version`}}.box",
       "type": "vagrant",
       "vagrantfile_template": "{{template_dir}}/tpl/vagrantfile-win81x86-pro.tpl"
     }


### PR DESCRIPTION
This PR simply replaces all of the `vm_name` keys defined in the builders with a user-variable `vm_name`. This makes it easier to change the "vm_name" by only needing to update it in one place.

The suffix for the `*-cygwin.json` and `*-ssh.json` templates was also made into a user variable (`vm_suffix`) in case the full name is desired to be controlled. As another benefit, this gives the user the ability to fully control the name of the box that is emitted.

The `vagrantfile_template` and any files that re-use the template name are not included as these are specific to the the template and so were considered part of the actual template. The output name in the post-processors is now 100% controlled by the user variables (excluding the hyphens).