### PR TITLE
Fix the floppy_files for the hyperv-iso builder belonging to eval-win7x86-enterprise-ssh.json template

### DIFF
--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -115,6 +115,7 @@
         "{{template_dir}}/floppy/fixnetwork.ps1",
         "{{template_dir}}/floppy/install-winrm.cmd",
         "{{template_dir}}/floppy/networkprompt.bat",
+        "{{template_dir}}/floppy/openssh.bat",
         "{{template_dir}}/floppy/passwordchange.bat",
         "{{template_dir}}/floppy/powerconfig.bat",
         "{{template_dir}}/floppy/zz-start-transports.cmd"


### PR DESCRIPTION
As a result of merging PR #222, it was discovered that the eval-win7x86-enterprise-ssh.json template is missing an important file (floppy/openssh.bat) in the floppy_files field that is required to install ssh. This PR fixes that by adding that missing file.

This closes issue #224.