### PR TITLE
Fix the floppy_files for the hyperv-iso builder belonging to win2012r2-standard-cygwin.json template

### DIFF
--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -122,8 +122,9 @@
         "{{template_dir}}/floppy/01-install-wget.cmd",
         "{{template_dir}}/floppy/_download.cmd",
         "{{template_dir}}/floppy/_packer_config.cmd",
+        "{{template_dir}}/floppy/cygwin.bat",
+        "{{template_dir}}/floppy/cygwin.sh",
         "{{template_dir}}/floppy/install-winrm.cmd",
-        "{{template_dir}}/floppy/openssh.bat",
         "{{template_dir}}/floppy/passwordchange.bat",
         "{{template_dir}}/floppy/powerconfig.bat",
         "{{template_dir}}/floppy/zz-start-transports.cmd"


### PR DESCRIPTION
As a result of merging PR #222, it was discovered that the win2012r2-standard-cygwin.json template is using the wrong file (`floppy/openssh.bat`) in the floppy_files field of the hyperv-iso builder when it should be using `floppy/cygwin.bat` (and `floppy/cygwin.sh`). This results in the hyperv-iso builder for that template installing ssh and not cygwin which is contrary to what the template is supposed to do, and what its other builders are already doing.

This PR fixes the issue by replacing `floppy/openssh.bat` with both `floppy/cygwin.bat` and `floppy/cygwin.sh` which corresponds to what the other builders in the template are doing.
 
This closes issue #225.