### PR TITLE
User customization without forking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ rspec_html_reports
 
 .DS_Store
 
-floppy/_packer_config_*.cmd
+*.*.json
+floppy/*.*.*
+script/*.*.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Makefile.local
 rspec_html_reports
 
 .DS_Store
+
+floppy/_packer_config_*.cmd
+

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ ifndef CM_VERSION
 		CM_VERSION = latest
 	endif
 endif
+
 BOX_VERSION ?= $(shell cat VERSION)
 UPDATE ?= false
 GENERALIZE ?= false
@@ -154,117 +155,117 @@ define SHORTCUT
 
 ifeq ($(UNAME_S),Darwin)
 
-$(1): $(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+$(PREFIX)$(1): $(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-$(1)-cygwin: $(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+$(PREFIX)$(1)-cygwin: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-$(1)-ssh: $(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+$(PREFIX)$(1)-ssh: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-$(PREFIX)$(1): test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-$(PREFIX)$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-$(PREFIX)$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-s3cp-$(1): s3cp-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) s3cp-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX) s3cp-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-$(PREFIX)$(1): s3cp-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) s3cp-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) s3cp-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
 else
 
-$(1): $(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+$(PREFIX)$(1): $(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-$(1)-cygwin: $(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+$(PREFIX)$(1)-cygwin: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-$(1)-ssh: $(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+$(PREFIX)$(1)-ssh: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-$(PREFIX)$(1): test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-$(PREFIX)$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-$(PREFIX)$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX) test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-s3cp-$(1): s3cp-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX) s3cp-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-$(PREFIX)$(1): s3cp-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX) s3cp-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
 endif
 
-vmware/$(1): $(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
+vmware/$(PREFIX)$(1): $(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-vmware/$(1)-cygwin: $(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+vmware/$(PREFIX)$(1)-cygwin: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-vmware/$(1)-ssh: $(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+vmware/$(PREFIX)$(1)-ssh: $(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-virtualbox/$(1): $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+virtualbox/$(PREFIX)$(1): $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-virtualbox/$(1)-cygwin: $(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+virtualbox/$(PREFIX)$(1)-cygwin: $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-virtualbox/$(1)-ssh: $(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+virtualbox/$(PREFIX)$(1)-ssh: $(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-parallels/$(1): $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+parallels/$(PREFIX)$(1): $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-parallels/$(1)-cygwin: $(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+parallels/$(PREFIX)$(1)-cygwin: $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-parallels/$(1)-ssh: $(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+parallels/$(PREFIX)$(1)-ssh: $(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-hyperv/$(1): $(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+hyperv/$(PREFIX)$(1): $(HYPERV_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-hyperv/$(1)-cygwin: $(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+hyperv/$(PREFIX)$(1)-cygwin: $(HYPERV_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-hyperv/$(1)-ssh: $(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+hyperv/$(PREFIX)$(1)-ssh: $(HYPERV_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-vmware/$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-vmware/$(PREFIX)$(1): test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-vmware/$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-vmware/$(PREFIX)$(1)-cygwin: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-vmware/$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-vmware/$(PREFIX)$(1)-ssh: test-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-virtualbox/$(PREFIX)$(1): test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-virtualbox/$(1)-cygwin: test-$(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-virtualbox/$(PREFIX)$(1)-cygwin: test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-virtualbox/$(1)-ssh: test-$(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-virtualbox/$(PREFIX)$(1)-ssh: test-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-parallels/$(1): test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-parallels/$(PREFIX)$(1): test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-parallels/$(1)-cygwin: test-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-parallels/$(PREFIX)$(1)-cygwin: test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-parallels/$(1)-ssh: test-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-parallels/$(PREFIX)$(1)-ssh: test-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-test-hyperv/$(1): test-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+test-hyperv/$(PREFIX)$(1): test-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-test-hyperv/$(1)-cygwin: test-$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+test-hyperv/$(PREFIX)$(1)-cygwin: test-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-test-hyperv/$(1)-ssh: test-$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+test-hyperv/$(PREFIX)$(1)-ssh: test-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-ssh-vmware/$(1): ssh-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-vmware/$(PREFIX)$(1): ssh-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-ssh-vmware/$(1)-cygwin: ssh-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+ssh-vmware/$(PREFIX)$(1)-cygwin: ssh-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-ssh-vmware/$(1)-ssh: ssh-$(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+ssh-vmware/$(PREFIX)$(1)-ssh: ssh-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-ssh-virtualbox/$(1): ssh-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-virtualbox/$(PREFIX)$(1): ssh-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-ssh-virtualbox/$(1)-cygwin: ssh-$(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+ssh-virtualbox/$(PREFIX)$(1)-cygwin: ssh-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-ssh-virtualbox/$(1)-ssh: ssh-$(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+ssh-virtualbox/$(PREFIX)$(1)-ssh: ssh-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-ssh-parallels/$(1): ssh-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-parallels/$(PREFIX)$(1): ssh-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-ssh-parallels/$(1)-cygwin: ssh-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+ssh-parallels/$(PREFIX)$(1)-cygwin: ssh-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-ssh-parallels/$(1)-ssh: ssh-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+ssh-parallels/$(PREFIX)$(1)-ssh: ssh-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-ssh-hyperv/$(1): ssh-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-hyperv/$(PREFIX)$(1): ssh-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-ssh-hyperv/$(1)-cygwin: ssh-$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX)
+ssh-hyperv/$(PREFIX)$(1)-cygwin: ssh-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX)
 
-ssh-hyperv/$(1)-ssh: ssh-$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX)
+ssh-hyperv/$(PREFIX)$(1)-ssh: ssh-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX)
 
-s3cp-vmware/$(1): s3cp-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-vmware/$(PREFIX)$(1): s3cp-$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-s3cp-virtualbox/$(1): s3cp-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-virtualbox/$(PREFIX)$(1): s3cp-$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-s3cp-parallels/$(1): s3cp-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-parallels/$(PREFIX)$(1): s3cp-$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 
-s3cp-hyperv/$(1): s3cp-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX)
+s3cp-hyperv/$(PREFIX)$(1): s3cp-$(HYPERV_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX)
 endef
 
 SHORTCUT_TARGETS := $(basename $(TEMPLATE_FILENAMES))
@@ -408,65 +409,65 @@ test-eval-openssh: test-eval-win2012r2-datacenter test-eval-win2008r2-datacenter
 
 define BUILDBOX
 
-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
+$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX): $(PREFIX)$(1).json
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1).json
 
-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
+$(VMWARE_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX): $(PREFIX)$(1).json
 	rm -rf $(VMWARE_OUTPUT)
 	mkdir -p $(VMWARE_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1).json
 
-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
+$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX): $(PREFIX)$(1).json
 	rm -rf $(PARALLELS_OUTPUT)
 	mkdir -p $(PARALLELS_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1).json
 
-$(HYPERV_BOX_DIR)/$(1)$(BOX_SUFFIX): $(1).json
+$(HYPERV_BOX_DIR)/$(PREFIX)$(1)$(BOX_SUFFIX): $(PREFIX)$(1).json
 	rm -rf $(HYPERV_OUTPUT)
 	mkdir -p $(HYPERV_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1).json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1).json
 
-$(VIRTUALBOX_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
+$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX): $(PREFIX)$(1)-ssh.json
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-ssh.json
 
-$(VMWARE_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
+$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX): $(PREFIX)$(1)-ssh.json
 	rm -rf $(VMWARE_OUTPUT)
 	mkdir -p $(VMWARE_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
+	$(PACKER) build -on-error=$(ON_ERROR) -only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-ssh.json
 
-$(PARALLELS_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
+$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX): $(PREFIX)$(1)-ssh.json
 	rm -rf $(PARALLELS_OUTPUT)
 	mkdir -p $(PARALLELS_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-ssh.json
 
-$(HYPERV_BOX_DIR)/$(1)-ssh$(BOX_SUFFIX): $(1)-ssh.json
+$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-ssh$(BOX_SUFFIX): $(PREFIX)$(1)-ssh.json
 	rm -rf $(HYPERV_OUTPUT)
 	mkdir -p $(HYPERV_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-ssh.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-ssh.json
 
-$(VIRTUALBOX_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
+$(VIRTUALBOX_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX): $(PREFIX)$(1)-cygwin.json
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-cygwin.json
 
-$(VMWARE_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
+$(VMWARE_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX): $(PREFIX)$(1)-cygwin.json
 	rm -rf $(VMWARE_OUTPUT)
 	mkdir -p $(VMWARE_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(VMWARE_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-cygwin.json
 
-$(PARALLELS_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
+$(PARALLELS_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX): $(PREFIX)$(1)-cygwin.json
 	rm -rf $(PARALLELS_OUTPUT)
 	mkdir -p $(PARALLELS_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-cygwin.json
 
-$(HYPERV_BOX_DIR)/$(1)-cygwin$(BOX_SUFFIX): $(1)-cygwin.json
+$(HYPERV_BOX_DIR)/$(PREFIX)$(1)-cygwin$(BOX_SUFFIX): $(PREFIX)$(1)-cygwin.json
 	rm -rf $(HYPERV_OUTPUT)
 	mkdir -p $(HYPERV_BOX_DIR)
-	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(1)-cygwin.json
+	$(PACKER) build -on-error=$(ON_ERROR) --only=$(HYPERV_BUILDER) $(PACKER_VARS) -var "iso_url=$(2)" -var "iso_checksum=$(3)" $(PREFIX)$(1)-cygwin.json
 endef
 
 $(eval $(call BUILDBOX,win2008r2-datacenter,$(WIN2008R2_X64),$(WIN2008R2_X64_CHECKSUM)))

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ BOX_VERSION ?= $(shell cat VERSION)
 UPDATE ?= false
 GENERALIZE ?= false
 HEADLESS ?= false
+
+# Set 'make PREFIX=[prefix]' argument to prefix targets to use a user provided
+# custom Packer template named with a matching '[prefix].[os_name].json'.
+PREFIX ?=
+
 ifndef SHUTDOWN_COMMAND
 ifeq ($(GENERALIZE),true)
 	SHUTDOWN_COMMAND ?= C:/Windows/System32/Sysprep/sysprep.exe /generalize /shutdown /oobe /unattend:A:/Autounattend.xml


### PR DESCRIPTION
## User customization without forking

* Part of #179 so closing #179

_Note: Does not affect existing `make` commands if `PREFIX` is not set._

Users can clone boxcutter/windows and make user specific copies of Packer templates, scripts and configs they can edit that are ignored by git.  

* Packer `*.json` template files can be symlinks to files in another repo.
* Files in `floppy` and `script` cannot be symlinks but can be links to files in other repos.

This adds flexibility to customize and to easily sync with the upstream repo at any time!

```
cp eval-win10x64-enterprise.json [company].eval-win10x64-enterprise.json
make PREFIX=[company]. [company].[target]
rm -rf output-virtualbox-iso
mkdir -p box/virtualbox
packer build -on-error=cleanup -only=virtualbox-iso -var 'version=1.0.4' -var 'update=false' -var 'headless=false' -var "shutdown_command=shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown" -var "iso_url=file://./iso/win10x64.iso" -var "iso_checksum=a4ea45ec1282e85fc84af49acf7a8d649c31ac5c" [company].eval-win10x64-enterprise.json
```

* Add `$(PREFIX)` to the `Makefile`
  * Run `make PREFIX=[company]. [company].[target]` to build from `[company].target.json`
* Add user customization ignores to the `.gitignore` floppy and script folders:
  * `*.*.json`
  * `floppy/*.*.*`
  * `script/*.*.*`

I use it as follows:

I have a repo in Github with my customizations that are business specific:

    floppy/*
        Scripts - Proxy Settings
        SSL Certs - Required to get to the internet so I can build. (IT Security Requiremnt)
    scripts/*
        Any business specific custom script that should not be in this repo.
    Makefile.local
    Packer Templates
    link_repos.sh
        Clones boxcutter/windows to ./boxcutter_windows
        Symlinks required files/folders from my repo into ./boxcutter_windows/*
            These links are added to the ./boxcutter\windows\.gitignore by this PR.
        Links required files from [my repo]/floppy into ./boxcutter_windows/floppy/*
            Symlinks don't work here
        Links required files from [my repo]/scripts into ./boxcutter_windows/scripts/*
            Symlinks don't work here

I can now use boxcutter/windows unmodified with my user customizations that have no business being in your repo and everything is still in source control.

I think this is a great add to this project for users that need user customizations and don't want to fork and keep their personal repo synched with this repo.