### PR TITLE
Add option to disable bits

### DIFF
--- a/floppy/01-install-wget.cmd
+++ b/floppy/01-install-wget.cmd
@@ -28,6 +28,10 @@ powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%WGET_URL%'
 
 if exist "%filename%" goto exit0
 
+if defined DISABLE_BITS (
+    if "%DISABLE_BITS%" == "1" if not exist "%filename%" goto exit1
+)
+
 set bitsadmin=
 
 for %%i in (bitsadmin.exe) do set bitsadmin=%%~$PATH:i

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -60,6 +60,10 @@ if not errorlevel 1 if exist "%filename%" goto exit0
 
 :bitsadmin
 
+if defined DISABLE_BITS (
+    if "%DISABLE_BITS%" == "1" if not exist "%filename%" goto exit1
+)
+
 set bitsadmin=
 
 for %%i in (bitsadmin.exe) do set bitsadmin=%%~$PATH:i

--- a/floppy/_packer_config.cmd
+++ b/floppy/_packer_config.cmd
@@ -13,6 +13,11 @@
 :: Default: z:\c\packer_logs
 :: set PACKER_LOG_DIR=z:\c\packer_logs
 
+:: Uncomment the following to disable BITS so scripts can fail instead of hanging when
+:: BITS doesn't work right.
+:: Default: (unset)
+:: set DISABLE_BITS=1
+
 :: Uncomment the following to change the pagefile size in MB as set by
 :: floppy/pagefile.bat
 :: Default: 512


### PR DESCRIPTION
Allow disable of BITS.

* Part of #179 so closing #179

Edit `floppy\_packer_config.cmd`:

```
:: Uncomment the following to disable BITS so scripts can fail instead of hanging when
:: BITS doesn't work right.
:: Default: (unset)
:: set DISABLE_BITS=1
```

