### PR TITLE
Refactor _download.cmd so that Powershell is tried first before falling back to the other download methods.

### DIFF
--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -5,91 +5,127 @@
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
 
 set "url=%~1"
-
 set "filename=%~2"
 
-if not defined url echo ==^> ERROR: _download.cmd called without URL parameter. & goto exit1
+REM First validate the parameters that we were given.
+if not defined url (
+    echo ==^> ERROR: _download.cmd called without URL parameter.
+    goto exit1
+)
 
 if not defined filename set filename=%TEMP%\%~nx1
 
-if exist "%filename%" echo ==^> File "%filename%" already exists, skipping download. & goto exit0
+REM Then check to make sure the file hasn't already been downloaded to where the
+REM caller has specified. If it already happened, then we can simply exit here.
+:check_fileexists
+if exist "%filename%" (
+    echo ==^> File "%filename%" already exists, skipping download.
+    goto exit0
+)
 
+REM Otherwise we first check and see if the file already exists somewhere in
+REM our search path. If it does, then we will only need to copy it to where ever
+REM the caller specified.
+:check_copyfile
 set basename=
-
 for %%i in ("%url%") do set basename=%%~nxi
-
 if not defined basename goto download
 
 set found=
-
 @for %%i in (%PACKER_SEARCH_PATHS%) do @if not defined found @if exist "%%~i\%basename%" set found=%%~i\%basename%
-
 if not defined found goto download
 
+REM Use a good ol' reliable file-copy to put the file in its right place.
+:copyfile
 echo ==^> Copying "%found%" to "%filename%", skipping download.
-
 copy /y "%found%" "%filename%" && goto exit0
 
-:download
+echo ==^> Unable to copy file from "%found%" to "%filename%", re-downloading the file.
 
+REM Hm. Our reliable file-copy is apparently not-so-reliable, or the file really
+REM does need to be downloaded. So we proceed to use one of the following
+REM downloaders to download the file.
+:download
 echo ==^> Downloading "%url%" to "%filename%"
 
+REM First check to see if we have an instance of Powershell, and give it
+REM priority when downloading. This is due to the other methods being flakey
+REM and not working on all supported platforms. More importantly, things like
+REM wget.exe are hosted remotely, and so we're unable to update it or interact
+REM with it in any way. It can also be backdoored out from underneath us which
+REM we should be fairly concerned about...
+:check_powershell
+where powershell 1>NUL 2>NUL
+if errorlevel 1 goto check_wget
+
+powershell -Command "(New-Object System.Net.WebClient)" >NUL
+if errorlevel 1 goto check_wget
+
+REM Use powershell to actually download the file (best case)
+:powershell
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%url%', '%filename%')" <NUL
+goto check_file_downloaded
+
+REM So we weren't able to use Powershell, which means we need to figure out the
+REM path to wget.exe first. This should have been placed somewhere in our path
+REM during the build process. So, we start in the SystemRoot and continue
+REM through all of the search paths to try and find it. If that fails, then we
+REM continue onto the next downloader tool.
+:check_wget
 set wget=
-
 for %%i in (wget.exe) do set wget=%%~$PATH:i
-
 if defined wget goto wget
 
 @for %%i in (%SystemRoot% %PACKER_SEARCH_PATHS%) do @if not defined wget @if exist "%%~i\wget.exe" set wget=%%~i\wget.exe
 
-:wget
-
-if not exist "%wget%" goto powershell
+if not defined wget goto check_bitadmin
+if not exist "%wget%" goto check_bitsadmin
 
 if not defined PACKER_DEBUG set WGET_OPTS=--no-verbose
 
+REM Use wget to download the file to the path that was specified
+:wget
 "%wget%" --no-check-certificate %WGET_OPTS% -O "%filename%" "%url%"
+goto check_file_downloaded
 
-if not errorlevel 1 if exist "%filename%" goto exit0
-
-:powershell
-
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%url%', '%filename%')" <NUL
-
-if not errorlevel 1 if exist "%filename%" goto exit0
-
-:bitsadmin
-
+REM Check to see if we can legitimately use bitsadmin, and then verify that the
+REM command is somewhere in our PATH. We've hit the worst-possible case here,
+REM but we need to keep trying anyways as a lot of the tools that we use are
+REM hosted remotely.
+:check_bitsadmin
 if defined DISABLE_BITS (
     if "%DISABLE_BITS%" == "1" if not exist "%filename%" goto exit1
 )
 
 set bitsadmin=
-
 for %%i in (bitsadmin.exe) do set bitsadmin=%%~$PATH:i
 
 if not defined bitsadmin set bitsadmin=%SystemRoot%\System32\bitsadmin.exe
+if not exist "%bitsadmin%" goto exit1
 
-if not exist "%bitsadmin%" goto powershell
-
+REM Use bitsadmin to "transfer" the file by creating a jobname for the specified
+REM filename, and then initiating the transfer.
+:bitsadmin
 for %%i in ("%filename%") do set jobname=%%~nxi
 
 "%bitsadmin%" /transfer "%jobname%" "%url%" "%filename%"
+goto check_file_downloaded
 
+REM We were able to use a download tool, so now we need to double check if it
+REM either failed, or if our file still doesn't exist yet. If it set an
+REM our download tool set an ERRORLEVEL or the file doesn't exist then we've
+REM failed pretty hard and we need to let the calling script know.
+:check_file_downloaded
 if not errorlevel 1 if exist "%filename%" goto exit0
 
 echo ==^> ERROR: Failed to download "%url%" to "%filename%"
-
 goto :exit1
 
 :exit0
-
 ver>nul
-
 goto :exit
 
 :exit1
-
 verify other 2>nul
 
 :exit

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -95,6 +95,9 @@ if defined wget goto wget
 if not defined wget goto check_bitadmin
 if not exist "%wget%" goto check_bitsadmin
 
+"%wget%" 2>NUL
+if errorlevel 1 goto check_bitsadmin
+
 if not defined PACKER_DEBUG set WGET_OPTS=--no-verbose
 
 REM Use wget to download the file to the path that was specified

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -92,7 +92,7 @@ if defined wget goto wget
 
 @for %%i in (%SystemRoot% %PACKER_SEARCH_PATHS%) do @if not defined wget @if exist "%%~i\wget.exe" set wget=%%~i\wget.exe
 
-if not defined wget goto check_bitadmin
+if not defined wget goto check_bitsadmin
 if not exist "%wget%" goto check_bitsadmin
 
 "%wget%" --version >NUL 2>NUL

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -61,9 +61,23 @@ if errorlevel 1 goto check_wget
 powershell -Command "(New-Object System.Net.WebClient)" >NUL
 if errorlevel 1 goto check_wget
 
+REM Check to see if our instance of Powershell supports at least TLS v1.2 (.NET
+REM Framework 4.5). This is because most of the internet is now enforcing that
+REM particular version of TLS. So if we can't use it, we're forced to deal and
+REM will have to use wget.exe instead.
+
+REM [Net.SecurityProtocolType]::Ssl3 - 48
+REM [Net.SecurityProtocolType]::Tls - 192
+REM [Net.SecurityProtocolType]::Tls11 - 768
+REM [Net.SecurityProtocolType]::Tls12 - 3072
+REM [Net.SecurityProtocolType]::Tls13 - 12288
+
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = 4080"
+if errorlevel 1 goto check_wget
+
 REM Use powershell to actually download the file (best case)
 :powershell
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%url%', '%filename%')" <NUL
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = 4080; (New-Object System.Net.WebClient).DownloadFile('%url%', '%filename%')" <NUL
 goto check_file_downloaded
 
 REM So we weren't able to use Powershell, which means we need to figure out the

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -95,7 +95,7 @@ if defined wget goto wget
 if not defined wget goto check_bitadmin
 if not exist "%wget%" goto check_bitsadmin
 
-"%wget%" 2>NUL
+"%wget%" --version >NUL 2>NUL
 if errorlevel 1 goto check_bitsadmin
 
 if not defined PACKER_DEBUG set WGET_OPTS=--no-verbose

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -58,7 +58,7 @@ REM we should be fairly concerned about...
 where powershell 1>NUL 2>NUL
 if errorlevel 1 goto check_wget
 
-powershell -Command "(New-Object System.Net.WebClient)" >NUL
+powershell -Command "(New-Object System.Net.WebClient)" >NUL 2>NUL
 if errorlevel 1 goto check_wget
 
 REM Check to see if our instance of Powershell supports at least TLS v1.2 (.NET
@@ -72,7 +72,7 @@ REM [Net.SecurityProtocolType]::Tls11 - 768
 REM [Net.SecurityProtocolType]::Tls12 - 3072
 REM [Net.SecurityProtocolType]::Tls13 - 12288
 
-powershell -Command "[Net.ServicePointManager]::SecurityProtocol = 4080"
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = 4080" >NUL 2>NUL
 if errorlevel 1 goto check_wget
 
 REM Use powershell to actually download the file (best case)
@@ -98,11 +98,11 @@ if not exist "%wget%" goto check_bitsadmin
 "%wget%" --version >NUL 2>NUL
 if errorlevel 1 goto check_bitsadmin
 
-if not defined PACKER_DEBUG set WGET_OPTS=--no-verbose
+if not defined PACKER_DEBUG set WGET_OPTS=-nv
 
 REM Use wget to download the file to the path that was specified
 :wget
-"%wget%" --no-check-certificate %WGET_OPTS% -O "%filename%" "%url%"
+"%wget%" %WGET_OPTS% -O "%filename%" "%url%"
 goto check_file_downloaded
 
 REM Check to see if we can legitimately use bitsadmin, and then verify that the

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -138,10 +138,10 @@ for %%i in ("%filename%") do set jobname=%%~nxi
 
 goto check_file_downloaded
 
-REM We were able to use a download tool, so now we need to double check if it
-REM either failed, or if our file still doesn't exist yet. If it set an
-REM our download tool set an ERRORLEVEL or the file doesn't exist then we've
-REM failed pretty hard and we need to let the calling script know.
+REM We were able to use a download tool, but now we need to double check if it
+REM either failed, or if our file still doesn't exist yet. If either of these
+REM cases have happened, then we've failed pretty hard and we need to let our
+REM calling script know what's up.
 :check_file_downloaded
 if not errorlevel 1 if exist "%filename%" goto exit0
 

--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -4,9 +4,9 @@
 
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
 
-set url=%~1
+set "url=%~1"
 
-set filename=%~2
+set "filename=%~2"
 
 if not defined url echo ==^> ERROR: _download.cmd called without URL parameter. & goto exit1
 

--- a/floppy/bitvisessh.bat
+++ b/floppy/bitvisessh.bat
@@ -5,6 +5,11 @@ SET PACKER_DEBUG=true
 
 title Installing Bitvise SSH Server.  Please wait...
 
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to install the Bitvise SSH Server due to missing download tool
+  goto :exit1
+)
+
 if not defined BITVISE_URL set BITVISE_URL=http://dl.bitvise.com/BvSshServer-Inst.exe
 
 for %%i in (%BITVISE_URL%) do set BITVISE_EXE=%%~nxi
@@ -15,12 +20,12 @@ echo ==^> Creating "%BITVISE_DIR%"
 mkdir "%BITVISE_DIR%"
 pushd "%BITVISE_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%BITVISE_URL%" "%BITVISE_PATH%"
-) else (
-  echo ==^> Downloading "%BITVISE_URL%" to "%BITVISE_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%BITVISE_URL%', '%BITVISE_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%BITVISE_URL%" "%BITVISE_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %BITVISE_URL%
+  goto exit1
 )
+
 if not exist "%BITVISE_PATH%" goto exit1
 
 echo ==^> Blocking SSH port 22 on the firewall

--- a/floppy/cygwin.bat
+++ b/floppy/cygwin.bat
@@ -4,6 +4,11 @@
 
 title Installing Cygwin. Please wait...
 
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to install Cygwin due to missing download tool
+  goto :exit1
+)
+
 if not defined CYGWIN_ARCH (
   :: Force CYGWIN_ARCH to 32-bit - 64-bit seems to crash a lot
   set CYGWIN_ARCH=x86
@@ -31,13 +36,13 @@ echo ==^> Creating "%CYGWIN_DIR%"
 mkdir "%CYGWIN_DIR%"
 pushd "%CYGWIN_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%CYGWIN_URL%" "%CYGWIN_PATH%"
-) else (
-  echo ==^> Downloading "%CYGWIN_URL%" to "%CYGWIN_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%CYGWIN_URL%', '%CYGWIN_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%CYGWIN_URL%" "%CYGWIN_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %CYGWIN_URL%
+  goto exit1
 )
-if errorlevel 1 goto exit1
+
+if not exist "%CYGWIN_PATH%" goto exit1
 
 echo ==^> Blocking SSH port 22 on the firewall
 netsh advfirewall firewall add rule name="SSHD" dir=in action=block program="%CYGWIN_HOME%\usr\sbin\sshd.exe" enable=yes

--- a/floppy/hotfix-KB2842230.bat
+++ b/floppy/hotfix-KB2842230.bat
@@ -17,6 +17,11 @@ if %_minor% gtr 3 goto :exit
 
 title Installing Hotfix KB2842230. Please wait...
 
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to install Hotfix KB2842230 due to missing download tool
+  goto :exit1
+)
+
 if not defined HOTFIX_2842230_URL set HOTFIX_2842230_URL=https://chocolateypackages.s3.amazonaws.com/KB2842230.1.0.2.nupkg
 
 for %%i in (%HOTFIX_2842230_URL%) do set HOTFIX_2842230_EXE=%%~nxi
@@ -27,13 +32,13 @@ echo ==^> Creating "%HOTFIX_2842230_DIR%"
 mkdir "%HOTFIX_2842230_DIR%"
 pushd "%HOTFIX_2842230_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%HOTFIX_2842230_URL%" "%HOTFIX_2842230_PATH%"
-) else (
-  echo ==^> Downloading "%HOTFIX_2842230_URL%" to "%HOTFIX_2842230_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%HOTFIX_2842230_URL%', '%HOTFIX_2842230_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%HOTFIX_2842230_URL%" "%HOTFIX_2842230_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %HOTFIX_2842230_URL%
+  goto exit1
 )
-if errorlevel 1 goto exit1
+
+if not exist "%HOTFIX_2842230_PATH%" goto exit1
 
 echo ==^> Extracting Hotfix KB2842230
 @for %%i in (%~dp0\unzip.vbs) do @cscript //nologo "%%~i" "%HOTFIX_2842230_PATH%" "%HOTFIX_2842230_DIR%"

--- a/floppy/openssh.bat
+++ b/floppy/openssh.bat
@@ -4,6 +4,11 @@
 
 title Installing Openssh. Please wait...
 
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to install Openssh due to missing download tool
+  goto :exit1
+)
+
 if not defined OPENSSH_URL set OPENSSH_URL=http://www.mls-software.com/files/setupssh-7.2p2-1-v1.exe
 if not defined SSHD_PASSWORD  set SSHD_PASSWORD=D@rj33l1ng
 
@@ -15,12 +20,12 @@ echo ==^> Creating "%OPENSSH_DIR%"
 mkdir "%OPENSSH_DIR%"
 pushd "%OPENSSH_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%OPENSSH_URL%" "%OPENSSH_PATH%"
-) else (
-  echo ==^> Downloading "%OPENSSH_URL%" to "%OPENSSH_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%OPENSSH_URL%', '%OPENSSH_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%OPENSSH_URL%" "%OPENSSH_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %OPENSSH_URL%
+  goto exit1
 )
+
 if not exist "%OPENSSH_PATH%" goto exit1
 
 echo ==^> Blocking SSH port 22 on the firewall

--- a/floppy/upgrade-wua.bat
+++ b/floppy/upgrade-wua.bat
@@ -4,6 +4,11 @@
 
 title Upgrading Windows Update Agent.  Please wait...
 
+if not exist "%SystemRoot%\_download.cmd" (
+    echo ==^> ERROR: Unable to upgrade the Windows Update Agent due to missing download tool
+    goto :exit1
+)
+
 if not defined WUA_64_URL set WUA_64_URL=http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
 if not defined WUA_32_URL set WUA_32_URL=http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x86.exe
 
@@ -20,12 +25,12 @@ set WUA_PATH=%WUA_DIR%\%WUA_EXE%
 echo ==^> Creating "%WUA_DIR%"
 mkdir "%WUA_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-    call "%SystemRoot%\_download.cmd" "%WUA_URL%" "%WUA_PATH%"
-) else (
-    echo ==^> Downloading "%WUA_URL%" to "%WUA_PATH%"
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%WUA_URL%', '%WUA_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%WUA_URL%" "%WUA_PATH%"
+if errorlevel 1 (
+    echo ==^> ERROR: Unable to download file from %WUA_URL%
+    goto exit1
 )
+
 if not exist "%WUA_PATH%" goto exit1
 
 echo ==^> Upgrading Windows Update Agent

--- a/script/01-install-handle.cmd
+++ b/script/01-install-handle.cmd
@@ -2,6 +2,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and installing SysInternals' Handle. Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to download and install SysInternals' Handle due to missing download tool
+  goto :exit1
+)
+
 if not defined HANDLE_URL set HANDLE_URL=http://live.sysinternals.com/handle.exe
 
 for %%i in ("%HANDLE_URL%") do set HANDLE_EXE=%%~nxi
@@ -12,12 +19,12 @@ echo ==^> Creating "%HANDLE_DIR%"
 mkdir "%HANDLE_DIR%"
 pushd "%HANDLE_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%HANDLE_URL%" "%HANDLE_PATH%"
-) else (
-  echo ==^> Downloading "%HANDLE_URL%" to "%HANDLE_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%HANDLE_URL%', '%HANDLE_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%HANDLE_URL%" "%HANDLE_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %HANDLE_URL%
+  goto exit1
 )
+
 if not exist "%HANDLE_PATH%" goto exit1
 
 reg add HKCU\Software\Sysinternals\Handle /v EulaAccepted /t REG_DWORD /d 1 /f

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -2,6 +2,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and deploying configuration management tool.  Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+    echo ==^> ERROR: Unable to download configuration management tool due to missing download tool
+    goto :exit1
+)
+
 :: Get the PlatformVersion from SystemInfo
 for /f "delims=:; tokens=1,2" %%a in ('systeminfo') do (
   if "%%a" == "OS Version" set PlatformVersionRow=%%b
@@ -134,12 +141,12 @@ echo ==^> Creating "%CHEF_DIR%"
 mkdir "%CHEF_DIR%"
 pushd "%CHEF_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%CHEF_URL%" "%CHEF_PATH%"
-) else (
-  echo ==^> Downloading %CHEF_URL% to %CHEF_PATH%
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile(\"%CHEF_URL%\", '%CHEF_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%CHEF_URL%" "%CHEF_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %CHEF_URL%
+  goto exit1
 )
+
 if not exist "%CHEF_PATH%" goto exit1
 
 echo ==^> Installing %CM% %CM_VERSION%
@@ -213,12 +220,12 @@ mkdir "%PUPPET_DIR%"
 pushd "%PUPPET_DIR%"
 
 :: todo support CM_VERSION variable
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%PUPPET_URL%" "%PUPPET_PATH%"
-) else (
-  echo ==^> Downloading %PUPPET_URL% to %PUPPET_PATH%
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%PUPPET_URL%', '%PUPPET_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%PUPPET_URL%" "%PUPPET_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %PUPPET_URL%
+  goto exit1
 )
+
 if not exist "%PUPPET_PATH%" goto exit1
 
 echo ==^> Installing Puppet client %CM_VERSION%

--- a/script/sdelete.bat
+++ b/script/sdelete.bat
@@ -2,6 +2,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and running SysInternals' SDelete to optimize the empty space of the image.  Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+    echo ==^> ERROR: Unable to download SysInternals' SDelete due to missing download tool
+    goto :exit1
+)
+
 if not defined SDELETE_URL set SDELETE_URL=http://web.archive.org/web/20160404120859if_/http://live.sysinternals.com/sdelete.exe
 
 for %%i in ("%SDELETE_URL%") do set SDELETE_EXE=%%~nxi
@@ -12,12 +19,12 @@ echo ==^> Creating "%SDELETE_DIR%"
 mkdir "%SDELETE_DIR%"
 pushd "%SDELETE_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%SDELETE_URL%" "%SDELETE_PATH%"
-) else (
-  echo ==^> Downloading "%SDELETE_URL%" to "%SDELETE_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SDELETE_URL%', '%SDELETE_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%SDELETE_URL%" "%SDELETE_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %SDELETE_URL%
+  goto exit1
 )
+
 if not exist "%SDELETE_PATH%" goto exit1
 
 reg add HKCU\Software\Sysinternals\SDelete /v EulaAccepted /t REG_DWORD /d 1 /f

--- a/script/ultradefrag.bat
+++ b/script/ultradefrag.bat
@@ -2,6 +2,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and running UltraDefrag to optimize the disk space usage of the image.  Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to download UltraDefrag due to missing download tool
+  goto :exit1
+)
+
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
 
 if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
@@ -51,12 +58,12 @@ echo ==^> Creating "%SEVENZIP_DIR%"
 mkdir "%SEVENZIP_DIR%"
 cd /d "%SEVENZIP_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%SEVENZIP_URL%" "%SEVENZIP_PATH%"
-) else (
-  echo ==^> Downloading "%SEVENZIP_URL%" to "%SEVENZIP_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%SEVENZIP_URL%" "%SEVENZIP_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %SEVENZIP_URL%
+  goto exit1
 )
+
 if not exist "%SEVENZIP_PATH%" goto return1
 
 echo ==^> Installing "%SEVENZIP_PATH%"
@@ -129,12 +136,12 @@ echo ==^> Creating "%ULTRADEFRAG_DIR%"
 mkdir "%ULTRADEFRAG_DIR%"
 pushd "%ULTRADEFRAG_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%ULTRADEFRAG_URL%" "%ULTRADEFRAG_PATH%"
-) else (
-  echo ==^> Downloading "%ULTRADEFRAG_URL%" to "%ULTRADEFRAG_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%ULTRADEFRAG_URL%', '%ULTRADEFRAG_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%ULTRADEFRAG_URL%" "%ULTRADEFRAG_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %ULTRADEFRAG_URL%
+  goto exit1
 )
+
 if not exist "%ULTRADEFRAG_PATH%" goto exit1
 
 call :install_sevenzip

--- a/script/vagrant.bat
+++ b/script/vagrant.bat
@@ -2,6 +2,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and deploying vagrant public key.  Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to download and deploy vagrant public key due to missing download tool
+  goto :exit1
+)
+
 if not defined VAGRANT_PUB_URL set VAGRANT_PUB_URL=https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub
 
 for %%i in ("%VAGRANT_PUB_URL%") do set VAGRANT_PUB=%%~nxi
@@ -13,12 +20,12 @@ echo ==^> Creating "%VAGRANT_DIR%"
 mkdir "%VAGRANT_DIR%"
 pushd "%VAGRANT_DIR%"
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%VAGRANT_PUB_URL%" "%VAGRANT_PATH%"
-) else (
-  echo ==^> Downloading "%VAGRANT_PUB_URL%" to "%VAGRANT_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VAGRANT_PUB_URL%', '%VAGRANT_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%VAGRANT_PUB_URL%" "%VAGRANT_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file %VAGRANT_PUB_URL%
+  goto exit1
 )
+
 if not exist "%VAGRANT_PATH%" goto exit1
 
 echo ==^> Creating "%USERPROFILE%\.ssh"

--- a/script/vmtool.bat
+++ b/script/vmtool.bat
@@ -3,6 +3,13 @@
 @for %%i in (a:\_packer_config*.cmd) do @call "%%~i"
 @if defined PACKER_DEBUG (@echo on) else (@echo off)
 
+title Downloading and installing virtual machine tools.  Please wait...
+
+if not exist "%SystemRoot%\_download.cmd" (
+  echo ==^> ERROR: Unable to download virtual machine tools due to missing download tool
+  goto :exit1
+)
+
 if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b: c: d: e: f: g: h: i: j: k: l: m: n: o: p: q: r: s: t: u: v: w: x: y: z:
 if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
 if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=http://7-zip.org/a/7z1604-x64.msi
@@ -38,13 +45,15 @@ set SEVENZIP_PATH=%SEVENZIP_DIR%\%SEVENZIP_MSI%
 echo ==^> Creating "%SEVENZIP_DIR%"
 mkdir "%SEVENZIP_DIR%"
 cd /d "%SEVENZIP_DIR%"
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%SEVENZIP_URL%" "%SEVENZIP_PATH%"
-) else (
-  echo ==^> Downloading "%SEVENZIP_URL%" to "%SEVENZIP_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SEVENZIP_URL%', '%SEVENZIP_PATH%')" <NUL
+
+call "%SystemRoot%\_download.cmd" "%SEVENZIP_URL%" "%SEVENZIP_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %SEVENZIP_URL%
+  goto exit1
 )
+
 if not exist "%SEVENZIP_PATH%" goto return1
+
 echo ==^> Installing "%SEVENZIP_PATH%"
 msiexec /qb /i "%SEVENZIP_PATH%"
 @if errorlevel 1 echo ==^> WARNING: Error %ERRORLEVEL% was returned by: msiexec /qb /i "%SEVENZIP_PATH%"
@@ -126,13 +135,15 @@ if defined VMWARE_TOOLS_ISO_PATH for %%i in (%VMWARE_TOOLS_ISO_PATH%) do set _VM
 if %_VMWARE_TOOLS_SIZE% EQU 0 set VMWARE_TOOLS_ISO_PATH=
 
 if defined VMWARE_TOOLS_ISO_PATH goto install_vmware_tools_from_iso
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%VMWARE_TOOLS_TAR_URL%" "%VMWARE_TOOLS_TAR_PATH%"
-) else (
-  echo ==^> Downloading "%VMWARE_TOOLS_TAR_URL%" to "%VMWARE_TOOLS_TAR_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VMWARE_TOOLS_TAR_URL%', '%VMWARE_TOOLS_TAR_PATH%')" <NUL
+
+call "%SystemRoot%\_download.cmd" "%VMWARE_TOOLS_TAR_URL%" "%VMWARE_TOOLS_TAR_PATH%"
+if errorlevel 1 (
+  echo ==^> ERRROR: Unable to download file from %VMWARE_TOOLS_TAR_URL%
+  goto exit1
 )
+
 if not exist "%VMWARE_TOOLS_TAR_PATH%" goto exit1
+
 call :install_sevenzip
 if errorlevel 1 goto exit1
 7z e -y -o"%VMWARE_TOOLS_DIR%" "%VMWARE_TOOLS_TAR_PATH%" *tools-windows*
@@ -202,12 +213,12 @@ set _VBOX_ISO_SIZE=0
 if exist "%VBOX_ISO_PATH%" for %%i in (%VBOX_ISO_PATH%) do set _VBOX_ISO_SIZE=%%~zi
 if %_VBOX_ISO_SIZE% GTR 0 goto install_vbox_guest_additions_from_iso
 
-if exist "%SystemRoot%\_download.cmd" (
-  call "%SystemRoot%\_download.cmd" "%VBOX_ISO_URL%" "%VBOX_ISO_PATH%"
-) else (
-  echo ==^> Downloading "%VBOX_ISO_URL%" to "%VBOX_ISO_PATH%"
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%VBOX_ISO_URL%', '%VBOX_ISO_PATH%')" <NUL
+call "%SystemRoot%\_download.cmd" "%VBOX_ISO_URL%" "%VBOX_ISO_PATH%"
+if errorlevel 1 (
+  echo ==^> ERROR: Unable to download file from %VBOX_ISO_URL%
+  goto exit1
 )
+
 if not exist "%VBOX_ISO_PATH%" goto exit1
 
 :install_vbox_guest_additions_from_iso


### PR DESCRIPTION
This PR tampers with all of the scripts so that they explicitly depend on `_download.cmd`. Technically they were doing that before, but they'd always fall back to using Powershell when failing which would also fail because `_download.cmd` was doing the exact same thing. Now we just fail the scripts at their beginning if we're unable to find the cached file and are unable download it.

The `_download.cmd` script was also refactored to change the order of the downloads that are tried. Now we give powershell priority, fallback to `wget.exe`, and then try `bitsadmin.exe` as a last resort. The powershell downloader also requires and sets the minimum security protocol version to Tls 1.2. This is due to the reason that most of tools that we're downloading are now being hosted on a Tls 1.2-only webserver which had broken most of the templates.

This closes issue #238.