### PR TITLE
Add prlctl to disable EFI mode

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -114,8 +114,16 @@
         "{{template_dir}}/3rdparty/curl.exe"
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -111,8 +111,16 @@
         "{{template_dir}}/3rdparty/curl.exe"
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -111,8 +111,16 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "communicator": "winrm",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -114,8 +114,16 @@
         "{{template_dir}}/3rdparty/curl.exe"
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -111,8 +111,16 @@
         "{{template_dir}}/3rdparty/curl.exe"
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -111,8 +111,16 @@
       ],
       "shutdown_command": "{{ user `shutdown_command`}}",
       "communicator": "winrm",
-      "guest_os_type": "win-8.1",
+      "guest_os_type": "win-10",
       "parallels_tools_flavor": "win",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{user `disk_size`}}",


### PR DESCRIPTION
Closes #244 at least for Windows 10. It seems many of the server templates already have this block.