### PR TITLE
[WIP] Removed the hardcoding of the 2019.2.2 version for "latest" when installing the "salt" configuration management tool

### DIFF
--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -26,12 +26,19 @@ echo ==^> Detected Windows Platform Version: %PlatformVersionMajor%.%PlatformVer
 if not defined TEMP set TEMP=%LOCALAPPDATA%\Temp
 
 :: Figure out which configuration management tool to use
-if not defined CM echo ==^> ERROR: The "CM" variable was not found in the environment & goto exit1
+if not defined CM (
+  echo ==^> ERROR: The "CM" variable was not found in the environment
+  goto exit1
+)
+
 if "%CM%" == "nocm" goto nocm
 
 if not defined CM_VERSION (
-  echo ==^> ERROR: The "CM_VERSION" variable was not found in the environment
+  echo ==^> Using default value of "latest" for the "CM_VERSION" environment variable
   set CM_VERSION=latest
+
+) else (
+  echo ==^> Found the value "%CM_VERSION%" in the "CM_VERSION" environment variable
 )
 
 if "%CM%" == "chef" goto omnitruck

--- a/script/cmtool.bat
+++ b/script/cmtool.bat
@@ -258,20 +258,13 @@ if "%PlatformVersionMajor%" == "6" if "%PlatformVersionMinor%" == "1" goto saltr
 :saltbootstrap
 ::::::::::::
 
-:: We hardcode the CM_VERSION here to workaround saltstack/salt-bootstrap#1394
-if "%CM_VERSION%" == "latest" set CM_VERSION=2019.2.2
-
 set SALT_URL=http://raw.githubusercontent.com/saltstack/salt-bootstrap/%SALT_REVISION%/bootstrap-salt.ps1
-
 set SALT_PATH=%SALT_DIR%\bootstrap-salt.ps1
-set SALT_DOWNLOAD=%SALT_DIR%\bootstrap-salt.download.ps1
 
-echo ==^> Downloading %SALT_URL% to %SALT_DOWNLOAD%
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_DOWNLOAD%')" <NUL
+echo ==^> Downloading %SALT_URL% to %SALT_PATH%
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%SALT_URL%', '%SALT_PATH%')" <NUL
 
-if not exist "%SALT_DOWNLOAD%" goto exit1
-echo ==^> Patching bootstrap-salt.ps1 at %SALT_DOWNLOAD%
-powershell -command "(get-content \"%SALT_DOWNLOAD%\") -replace \"'Tls,Tls11,Tls12'\", \"0xc0,0x300,0xc00\" | set-content \"%SALT_PATH%\""
+if not exist "%SALT_PATH%" goto exit1
 
 echo ==^> Installing Salt minion with %SALT_PATH%
 if "%CM_VERSION%" == "latest" (


### PR DESCRIPTION
Due to issue saltstack/salt#1394 which broke the "latest" parameter to salt-bootstrap, we were forced to explicitly test for it and hardcode the version. As that aforementioned issue was finally closed, this means we can remove this hardcoding from `script/cmtool.bat` entirely.

The majority of that hardcoding was done by commit 9645c5963291b8379acf75f72a07715b14af4ce8. so we can get by with reverting it and fixing a few things in order to remain consistent. There's still an ssl issue since earlier versions of windows do not support ssl versions earlier than 3. In order to deal with this other issue, this PR adds another script which installs KB3154518 on the platforms that it's necessary for.

This closes issue #251.