### PR TITLE
Updated the sourceforge.net URI for downloading ultradefrag so that it works properly with all available fallback downloaders

### DIFF
--- a/floppy/_download.cmd
+++ b/floppy/_download.cmd
@@ -146,7 +146,7 @@ REM Every other method so far has failed entirely, so at this point there's
 REM nothing left to try but curl.exe which came for free with the build. We
 REM first need to locate it and make sure that it actually works.
 :check_curl
-if not defined CURL_OPTS ( set "CURL_OPTS=-L" ) else if defined CURL_OPTS ( set "CURL_OPTS=%CURL_OPTS% -L" )
+if not defined CURL_OPTS ( set "CURL_OPTS=-A '' -L" ) else if defined CURL_OPTS ( set "CURL_OPTS=%CURL_OPTS% -A '' -L" )
 if defined PACKER_DEBUG if not "%PACKER_DEBUG%" == "0" set "CURL_OPTS=%CURL_OPTS% --verbose"
 
 set curl=

--- a/script/ultradefrag.bat
+++ b/script/ultradefrag.bat
@@ -14,8 +14,8 @@ if not defined PACKER_SEARCH_PATHS set PACKER_SEARCH_PATHS="%USERPROFILE%" a: b:
 if not defined SEVENZIP_32_URL set SEVENZIP_32_URL=http://7-zip.org/a/7z1604.msi
 if not defined SEVENZIP_64_URL set SEVENZIP_64_URL=http://www.7-zip.org/a/7z1604-x64.msi
 
-if not defined ULTRADEFRAG_32_URL set ULTRADEFRAG_32_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.i386.zip
-if not defined ULTRADEFRAG_64_URL set ULTRADEFRAG_64_URL=http://downloads.sourceforge.net/ultradefrag/ultradefrag-portable-7.0.2.bin.amd64.zip
+if not defined ULTRADEFRAG_32_URL set ULTRADEFRAG_32_URL=http://downloads.sourceforge.net/project/ultradefrag/stable-release/7.0.2/ultradefrag-portable-7.0.2.bin.i386.zip
+if not defined ULTRADEFRAG_64_URL set ULTRADEFRAG_64_URL=http://downloads.sourceforge.net/project/ultradefrag/stable-release/7.0.2/ultradefrag-portable-7.0.2.bin.amd64.zip
 
 goto :main
 


### PR DESCRIPTION
Part of the provisioning steps for each template downloads ultradefrag v7.0.2 and uses it to defragment the hard disk prior to completion. This is done by using the `floppy/_download.cmd` script to fetch the correct zip file based on the architecture, and then using 7zip to extract and run it. When downloading from sourceforge.net, sourceforget apparently looks at the user agent and uses that to determine whether to return a binary or a webpage with a meta-redirect. This results in some downloaders failing at downloading the archive and getting an html page instead. Specifically, this symptom affects both the powershell and curl fallback downloaders and occurs nearly all the time when using the W7 templates. I imagine this affects bitsadmin in the templates too, but haven't tested that particular variation because bitsadmin sucks.

This PR fixes the issue by pointing the download url for ultradefrag to one of the redirects that sourceforge gives you (fixes powershell), and by emptying the user-agent header in the downloaders headers that get sent to sourceforge.net (fixes curl). This should result in the redirects properly getting us to the actual .zip we're asking for. Both the downloader and the file that's downloaded are sanity-checked anyways, but this does a better job of guaranteeing that the defragmentation step will occur.

This closes issue #253.