### PR TITLE
Fix shutdown command

### DIFF
--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -215,7 +215,7 @@
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -211,7 +211,7 @@
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -203,7 +203,7 @@
     "iso_checksum": "3b5f9494d870726d6d8a833aaf6169a964b8a9be",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -215,7 +215,7 @@
     "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -211,7 +211,7 @@
     "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -203,7 +203,7 @@
     "iso_checksum": "4a75747a47eb689497fe57d64cec375c7949aa97",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -178,7 +178,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -174,7 +174,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -174,7 +174,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -170,7 +170,7 @@
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -195,7 +195,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -191,7 +191,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -187,7 +187,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -195,7 +195,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -191,7 +191,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -187,7 +187,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -195,7 +195,7 @@
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -191,7 +191,7 @@
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -187,7 +187,7 @@
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -186,7 +186,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -186,7 +186,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -178,7 +178,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -186,7 +186,7 @@
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -182,7 +182,7 @@
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -174,7 +174,7 @@
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -187,7 +187,7 @@
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -187,7 +187,7 @@
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -183,7 +183,7 @@
     "iso_checksum": "7c7d99546077c805faae40a8864882c46f0ca141",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -187,7 +187,7 @@
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -183,7 +183,7 @@
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -179,7 +179,7 @@
     "iso_checksum": "4ddd0881779e89d197cb12c684adf47fd5d9e540",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -174,7 +174,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -169,7 +169,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -174,7 +174,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -169,7 +169,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -174,7 +174,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -169,7 +169,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -178,7 +178,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -174,7 +174,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -169,7 +169,7 @@
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -190,7 +190,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -186,7 +186,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -181,7 +181,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -190,7 +190,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -186,7 +186,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -181,7 +181,7 @@
     "iso_checksum": "d09e752b1ee480bc7e93dfa7d5c3a9b8aac477ba",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -191,7 +191,7 @@
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -187,7 +187,7 @@
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -182,7 +182,7 @@
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -191,7 +191,7 @@
     "iso_checksum": "af9ef225a510d6d51c5520396452d4f1c1e06935",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -187,7 +187,7 @@
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -182,7 +182,7 @@
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -191,7 +191,7 @@
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -187,7 +187,7 @@
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -182,7 +182,7 @@
     "iso_checksum": "865494e969704be1c4496d8614314361d025775e",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -195,7 +195,7 @@
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -191,7 +191,7 @@
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -187,7 +187,7 @@
     "iso_checksum": "f185197af68fae4f0e06510a4579fc511ba27616",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -182,7 +182,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -178,7 +178,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -169,7 +169,7 @@
     "iso_checksum": "15ddabafa72071a06d5213b486a02d5b55cb7070",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -182,7 +182,7 @@
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -178,7 +178,7 @@
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -169,7 +169,7 @@
     "iso_checksum": "708e0338d4e2f094dfeb860347c84a6ed9e91d0c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -182,7 +182,7 @@
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -178,7 +178,7 @@
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -169,7 +169,7 @@
     "iso_checksum": "4e0450ac73ab6f9f755eb422990cd9c7a1f3509c",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -182,7 +182,7 @@
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -178,7 +178,7 @@
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -169,7 +169,7 @@
     "iso_checksum": "d5bd65e1b326d728f4fd146878ee0d9a3da85075",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -183,7 +183,7 @@
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -179,7 +179,7 @@
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -174,7 +174,7 @@
     "iso_checksum": "8fb332a827998f807a1346bef55969c6519668b9",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -183,7 +183,7 @@
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -179,7 +179,7 @@
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -174,7 +174,7 @@
     "iso_checksum": "e50a6f0f08e933f25a71fbc843827fe752ed0365",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -175,7 +175,7 @@
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -171,7 +171,7 @@
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -166,7 +166,7 @@
     "iso_checksum": "fe43558b4708b4b786bc3286924813b0aad21106",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -175,7 +175,7 @@
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -171,7 +171,7 @@
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -166,7 +166,7 @@
     "iso_checksum": "c2d6f5d06362b7cb17dfdaadfb848c760963b254",
     "guest_additions_url": "",
     "box_directory": "box/",
-    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
     "version": "0.1.0"

--- a/wip/win2008r2-standardcore-cygwin.json
+++ b/wip/win2008r2-standardcore-cygwin.json
@@ -31,7 +31,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-transports.cmd"
       ],
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
       "guest_os_type": "windows7srv-64",
       "tools_upload_flavor": "windows",
       "cpus": "{{ user `cpus` }}",
@@ -62,7 +62,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-transports.cmd"
       ],
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
       "guest_os_type": "Windows2008_64",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",

--- a/wip/win2008r2-standardcore.json
+++ b/wip/win2008r2-standardcore.json
@@ -30,7 +30,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-transports.cmd"
       ],
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
       "guest_os_type": "windows7srv-64",
       "tools_upload_flavor": "windows",
       "cpus": "{{ user `cpus` }}",
@@ -60,7 +60,7 @@
         "floppy/powerconfig.bat",
         "floppy/zz-start-transports.cmd"
       ],
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c 'Packer Shutdown'",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
       "guest_os_type": "Windows2008_64",
       "cpus": "{{ user `cpus` }}",
       "memory": "{{ user `memory` }}",


### PR DESCRIPTION
Fixes #255 

If you aren't using `make` to build templates you may have run into this issue.