### PR TITLE
add ability to adjust output_directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ endif
 ifdef CM_VERSION
 	PACKER_VARS += -var 'cm_version=$(CM_VERSION)'
 endif
+ifdef CUSTOM_PACKER_VARS
+	PACKER_VARS += $(CUSTOM_PACKER_VARS)
+endif
 ON_ERROR ?= cleanup
 PACKER ?= packer
 ifdef PACKER_DEBUG

--- a/eval-win10x64-enterprise-cygwin.json
+++ b/eval-win10x64-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -41,6 +42,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -88,6 +90,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -131,6 +134,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -218,6 +222,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win10x64-enterprise-ssh.json
+++ b/eval-win10x64-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -40,6 +41,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -86,6 +88,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -128,6 +131,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -214,6 +218,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win10x64-enterprise.json
+++ b/eval-win10x64-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -40,6 +41,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -86,6 +88,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -128,6 +131,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -206,6 +210,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win10x86-enterprise-cygwin.json
+++ b/eval-win10x86-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -41,6 +42,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -88,6 +90,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -131,6 +134,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -218,6 +222,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win10x86-enterprise-ssh.json
+++ b/eval-win10x86-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -40,6 +41,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -86,6 +88,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -128,6 +131,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -214,6 +218,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win10x86-enterprise.json
+++ b/eval-win10x86-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -40,6 +41,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -86,6 +88,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -128,6 +131,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -206,6 +210,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-datacenter-cygwin.json
+++ b/eval-win2008r2-datacenter-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-datacenter-ssh.json
+++ b/eval-win2008r2-datacenter-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-datacenter.json
+++ b/eval-win2008r2-datacenter.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-standard-cygwin.json
+++ b/eval-win2008r2-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-standard-ssh.json
+++ b/eval-win2008r2-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2008r2-standard.json
+++ b/eval-win2008r2-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -173,6 +177,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-datacenter-cygwin.json
+++ b/eval-win2012r2-datacenter-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -198,6 +202,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-datacenter-ssh.json
+++ b/eval-win2012r2-datacenter-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-datacenter.json
+++ b/eval-win2012r2-datacenter.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-standard-cygwin.json
+++ b/eval-win2012r2-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -198,6 +202,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-standard-ssh.json
+++ b/eval-win2012r2-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2012r2-standard.json
+++ b/eval-win2012r2-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2016-standard-cygwin.json
+++ b/eval-win2016-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -198,6 +202,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2016-standard-ssh.json
+++ b/eval-win2016-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win2016-standard.json
+++ b/eval-win2016-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x64-enterprise-cygwin.json
+++ b/eval-win7x64-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -37,6 +38,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -73,6 +75,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -189,6 +193,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x64-enterprise-ssh.json
+++ b/eval-win7x64-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -37,6 +38,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -73,6 +75,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -189,6 +193,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x64-enterprise.json
+++ b/eval-win7x64-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -37,6 +38,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -73,6 +75,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x86-enterprise-cygwin.json
+++ b/eval-win7x86-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -37,6 +38,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -73,6 +75,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -189,6 +193,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x86-enterprise-ssh.json
+++ b/eval-win7x86-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win7x86-enterprise.json
+++ b/eval-win7x86-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x64-enterprise-cygwin.json
+++ b/eval-win81x64-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -108,6 +111,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x64-enterprise-ssh.json
+++ b/eval-win81x64-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -108,6 +111,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x64-enterprise.json
+++ b/eval-win81x64-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -37,6 +38,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -80,6 +82,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -111,6 +114,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -186,6 +190,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x86-enterprise-cygwin.json
+++ b/eval-win81x86-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -108,6 +111,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x86-enterprise-ssh.json
+++ b/eval-win81x86-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -186,6 +190,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/eval-win81x86-enterprise.json
+++ b/eval-win81x86-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -108,6 +111,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -182,6 +186,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-datacenter-cygwin.json
+++ b/win2008r2-datacenter-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-datacenter-ssh.json
+++ b/win2008r2-datacenter-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-datacenter.json
+++ b/win2008r2-datacenter.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-enterprise-cygwin.json
+++ b/win2008r2-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-enterprise-ssh.json
+++ b/win2008r2-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-enterprise.json
+++ b/win2008r2-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-standard-cygwin.json
+++ b/win2008r2-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-standard-ssh.json
+++ b/win2008r2-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-standard.json
+++ b/win2008r2-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-web-cygwin.json
+++ b/win2008r2-web-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-web-ssh.json
+++ b/win2008r2-web-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2008r2-web.json
+++ b/win2008r2-web.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-datacenter-cygwin.json
+++ b/win2012-datacenter-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -110,6 +113,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -193,6 +197,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-datacenter-ssh.json
+++ b/win2012-datacenter-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -107,6 +110,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -189,6 +193,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-datacenter.json
+++ b/win2012-datacenter.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -70,6 +72,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -109,6 +112,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -184,6 +188,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-standard-cygwin.json
+++ b/win2012-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -110,6 +113,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -193,6 +197,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-standard-ssh.json
+++ b/win2012-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -107,6 +110,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -189,6 +193,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012-standard.json
+++ b/win2012-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -70,6 +72,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -109,6 +112,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -184,6 +188,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-datacenter-cygwin.json
+++ b/win2012r2-datacenter-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-datacenter-ssh.json
+++ b/win2012r2-datacenter-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -74,6 +76,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -110,6 +113,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-datacenter.json
+++ b/win2012r2-datacenter.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -75,6 +77,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -112,6 +115,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standard-cygwin.json
+++ b/win2012r2-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standard-ssh.json
+++ b/win2012r2-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -74,6 +76,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -110,6 +113,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standard.json
+++ b/win2012r2-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -75,6 +77,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -112,6 +115,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standardcore-cygwin.json
+++ b/win2012r2-standardcore-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standardcore-ssh.json
+++ b/win2012r2-standardcore-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -74,6 +76,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -110,6 +113,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2012r2-standardcore.json
+++ b/win2012r2-standardcore.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -75,6 +77,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -112,6 +115,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2016-standard-cygwin.json
+++ b/win2016-standard-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -198,6 +202,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2016-standard-ssh.json
+++ b/win2016-standard-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -113,6 +116,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -194,6 +198,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win2016-standard.json
+++ b/win2016-standard.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -78,6 +80,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -116,6 +119,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -190,6 +194,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-enterprise-cygwin.json
+++ b/win7x64-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-enterprise-ssh.json
+++ b/win7x64-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-enterprise.json
+++ b/win7x64-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-pro-cygwin.json
+++ b/win7x64-pro-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-pro-ssh.json
+++ b/win7x64-pro-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x64-pro.json
+++ b/win7x64-pro.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-enterprise-cygwin.json
+++ b/win7x86-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-enterprise-ssh.json
+++ b/win7x86-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-enterprise.json
+++ b/win7x86-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-pro-cygwin.json
+++ b/win7x86-pro-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -36,6 +37,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -71,6 +73,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -185,6 +189,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-pro-ssh.json
+++ b/win7x86-pro-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -69,6 +71,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -99,6 +102,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -181,6 +185,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win7x86-pro.json
+++ b/win7x86-pro.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -98,6 +101,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -172,6 +176,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-enterprise-cygwin.json
+++ b/win81x64-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -186,6 +190,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-enterprise-ssh.json
+++ b/win81x64-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -74,6 +76,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -182,6 +186,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-enterprise.json
+++ b/win81x64-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -75,6 +77,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -104,6 +107,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-pro-cygwin.json
+++ b/win81x64-pro-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -76,6 +78,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -105,6 +108,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -186,6 +190,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-pro-ssh.json
+++ b/win81x64-pro-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -74,6 +76,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -102,6 +105,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -182,6 +186,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x64-pro.json
+++ b/win81x64-pro.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -75,6 +77,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -104,6 +107,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -177,6 +181,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-enterprise-cygwin.json
+++ b/win81x86-enterprise-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -97,6 +100,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -178,6 +182,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-enterprise-ssh.json
+++ b/win81x86-enterprise-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -66,6 +68,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -94,6 +97,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -174,6 +178,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-enterprise.json
+++ b/win81x86-enterprise.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -169,6 +173,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-pro-cygwin.json
+++ b/win81x86-pro-cygwin.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -68,6 +70,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -97,6 +100,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -178,6 +182,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-pro-ssh.json
+++ b/win81x86-pro-ssh.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -34,6 +35,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -66,6 +68,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -94,6 +97,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -174,6 +178,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/win81x86-pro.json
+++ b/win81x86-pro.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -35,6 +36,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -67,6 +69,7 @@
     },
     {
       "type": "parallels-iso",
+      "output_directory": "{{ user `build_directory` }}output-parallels-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -96,6 +99,7 @@
     },
     {
       "type": "hyperv-iso",
+      "output_directory": "{{ user `build_directory` }}output-hyperv-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -169,6 +173,7 @@
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c Packer_Shutdown",
     "headless": "false",
     "update": "true",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "build_directory": ""
   }
 }

--- a/wip/win2008r2-standardcore-cygwin.json
+++ b/wip/win2008r2-standardcore-cygwin.json
@@ -9,11 +9,13 @@
     "cm_version": "",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
-    "update": "true"
+    "update": "true",
+    "build_directory": ""
   },
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -45,6 +47,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [

--- a/wip/win2008r2-standardcore.json
+++ b/wip/win2008r2-standardcore.json
@@ -9,11 +9,13 @@
     "cm_version": "",
     "iso_url": "iso/en_windows_server_2008_r2_with_sp1_vl_build_x64_dvd_617403.iso",
     "iso_checksum": "7e7e9425041b3328ccf723a0855c2bc4f462ec57",
-    "update": "true"
+    "update": "true",
+    "build_directory": ""
   },
   "builders": [
     {
       "type": "vmware-iso",
+      "output_directory": "{{ user `build_directory` }}output-vmware-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [
@@ -44,6 +46,7 @@
     },
     {
       "type": "virtualbox-iso",
+      "output_directory": "{{ user `build_directory` }}output-virtualbox-iso",
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "floppy_files": [


### PR DESCRIPTION
Fork default behavior: Same as upstream `output_directory`

Usage:
```sh
make XXX \
 CUSTOM_PACKER_VARS='-var build_directory=a/larger/dir/' \
 XXX_OUTPUT=a/larger/dir/output-XXX-iso`
```